### PR TITLE
Fixed inappropriate headers

### DIFF
--- a/articles/security/blueprints/payment-processing-blueprint.md
+++ b/articles/security/blueprints/payment-processing-blueprint.md
@@ -185,11 +185,11 @@ Edna Benson は受付担当兼、営業部長です。 彼女は、顧客情報�
 
 このアーキテクチャは、暗号化、データベース監査などの手段を使用して保存データを保護します。
 
-#### <a name="azure-storage"></a>Azure Storage (Azure Storage)
+#### <a name="azure-storage"></a>Azure Storage
 
 暗号化された保存データの要件を満たすために、すべての [Azure Storage](https://azure.microsoft.com/services/storage/) で [Storage サービスの暗号化](/azure/storage/storage-service-encryption)が使用されます。
 
-#### <a name="azure-sql-database"></a>の接続文字列
+#### <a name="azure-sql-database"></a>Azure SQL Database
 
 Azure SQL Database インスタンスは、次のデータベース セキュリティ対策を使用します。
 


### PR DESCRIPTION
Like the original text in English, we have the notation Storage Account. Also, since the header of SQL Database(https://docs.microsoft.com/ja-jp/azure/security/blueprints/payment-processing-blueprint#azure-sql-database) was erroneous, it was modified as it was originally.