### PR TITLE
rollback changes

### DIFF
--- a/articles/monitoring-and-diagnostics/monitoring-activity-log-schema.md
+++ b/articles/monitoring-and-diagnostics/monitoring-activity-log-schema.md
@@ -464,7 +464,7 @@ ms.locfileid: "37917229"
 | description  |セキュリティ イベントを説明する静的テキスト。 |
 | eventDataId |セキュリティ イベントの一意識別子。 |
 | eventName |セキュリティ イベントのフレンドリ名。 |
-| identity |セキュリティ イベントの一意リソース識別子。 |
+| id |セキュリティ イベントの一意リソース識別子。 |
 | level |イベントのレベル。 "Critical"、"Error"、"Warning"、"Informational"、"Verbose" のいずれかの値 |
 | resourceGroupName |リソースのリソース グループの名前。 |
 | resourceProviderName |Azure Security Center のリソース プロバイダーの名前。 常に "Microsoft.Security"。 |
@@ -544,7 +544,7 @@ ms.locfileid: "37917229"
 | description  |推奨イベントを説明する静的テキスト |
 | eventDataId | 推奨イベントの一意の識別子。 |
 | category | 常に "Recommendation" |
-| identity |推奨イベントの一意のリソース ID。 |
+| id |推奨イベントの一意のリソース ID。 |
 | level |イベントのレベル。 "Critical"、"Error"、"Warning"、"Informational"、"Verbose" のいずれかの値 |
 | operationName |操作の名前。  常に "Microsoft.Advisor/generateRecommendations/action"|
 | resourceGroupName |リソースのリソース グループの名前。 |


### PR DESCRIPTION
rollback changes of https://github.com/microsoftdocs/azure-docs.ja-jp/commit/fe373e1144c1fd9f9b7ae7881cf300572f332898#diff-9be870c2ed8a191065e6aec6c37935ec
In 'Security' section, original text is: 'id | Unique resource identifier of the security event.'
It is 'id'. (It is not 'identity'.)
In 'Recommendation' section, original text is: 'id | Unique resource identifier of the recommendation event.'
It is 'id'. (It is not 'identity'.)
In 'Mapping to diagnostic logs schema' section, original text is: 'identity | claims and authorization properties'
It is 'identity'.