### PR TITLE
fix package name and link

### DIFF
--- a/articles/azure-functions/functions-bindings-storage-queue.md
+++ b/articles/azure-functions/functions-bindings-storage-queue.md
@@ -37,7 +37,7 @@ Queue ストレージ バインディングは [Microsoft.Azure.WebJobs](http://
 
 ## <a name="packages---functions-2x"></a>パッケージ - Functions 2.x
 
-Queue ストレージ バインディングは [Microsoft.Azure.WebJobs](http://www.nuget.org/packages/Microsoft.Azure.WebJobs) NuGet パッケージのバージョン 3.x で提供されます。 パッケージのソース コードは、[azure-webjobs-sdk](https://github.com/Azure/azure-webjobs-sdk/tree/master/src/Microsoft.Azure.WebJobs.Storage/Queue) GitHub リポジトリにあります。
+Queue ストレージ バインディングは [Microsoft.Azure.WebJobs.Extensions.Storage](https://www.nuget.org/packages/Microsoft.Azure.WebJobs.Extensions.Storage) NuGet パッケージのバージョン 3.x で提供されます。 パッケージのソース コードは、[azure-webjobs-sdk](https://github.com/Azure/azure-webjobs-sdk/tree/master/src/Microsoft.Azure.WebJobs.Storage/Queue) GitHub リポジトリにあります。
 
 [!INCLUDE [functions-package-auto](../../includes/functions-package-auto.md)]
 


### PR DESCRIPTION
According to english version, right package name for queue binding is "Microsoft.Azure.WebJobs.Extensions.Storage", not "Microsoft.Azure.WebJobs".

  Azure Queue storage bindings for Azure Functions | Microsoft Docs
  https://docs.microsoft.com/en-us/azure/azure-functions/functions-bindings-storage-queue#packages---functions-2x