### PR TITLE
improve translation for 'knowledge base'

### DIFF
--- a/articles/cognitive-services/QnAMaker/Quickstarts/create-new-kb-go.md
+++ b/articles/cognitive-services/QnAMaker/Quickstarts/create-new-kb-go.md
@@ -24,9 +24,9 @@ ms.locfileid: "43770778"
 
 [Cognitive Services API アカウント](https://docs.microsoft.com/azure/cognitive-services/cognitive-services-apis-create-account)と **Microsoft QnA Maker API** を用意している必要があります。 [Azure ダッシュボード](https://portal.azure.com/#create/Microsoft.CognitiveServices)の有料サブスクリプション キーが必要です。
 
-## <a name="create-knowledge-base"></a>サポート技術情報を作成する
+## <a name="create-knowledge-base"></a>ナレッジ ベースを作成する
 
-次のコードでは、[Create](https://westus.dev.cognitive.microsoft.com/docs/services/5a93fcf85b4ccd136866eb37/operations/5ac266295b4ccd1554da75ff) メソッドを利用し、新しいサポート技術情報が作成されます。
+次のコードでは、[Create](https://westus.dev.cognitive.microsoft.com/docs/services/5a93fcf85b4ccd136866eb37/operations/5ac266295b4ccd1554da75ff) メソッドを利用し、新しいナレッジ ベースが作成されます。
 
 1. 適切な IDE で新しい Go プロジェクトを作成します。
 2. 次に示すコードを追加します。

--- a/articles/cognitive-services/QnAMaker/Quickstarts/create-new-kb-java.md
+++ b/articles/cognitive-services/QnAMaker/Quickstarts/create-new-kb-java.md
@@ -32,7 +32,7 @@ ms.locfileid: "43771368"
 
 ## <a name="create-knowledge-base"></a>ナレッジ ベースを作成する
 
-次のコードでは、[Create](https://westus.dev.cognitive.microsoft.com/docs/services/5a93fcf85b4ccd136866eb37/operations/5ac266295b4ccd1554da75ff) メソッドを利用し、新しいサポート技術情報が作成されます。
+次のコードでは、[Create](https://westus.dev.cognitive.microsoft.com/docs/services/5a93fcf85b4ccd136866eb37/operations/5ac266295b4ccd1554da75ff) メソッドを利用し、新しいナレッジ ベースが作成されます。
 
 1. 適切な IDE で新しい Java プロジェクトを作成します。
 1. その Java プロジェクトに [Google GSON ライブラリ](https://github.com/google/gson)を追加します。任意のプロジェクト管理ツール (Maven など) に依存関係を追加するか、.jar ファイルを手動で[作成](https://stackoverflow.com/questions/5258159/how-to-make-an-executable-jar-file)してインポートしてください。

--- a/articles/cognitive-services/QnAMaker/Quickstarts/create-new-kb-nodejs.md
+++ b/articles/cognitive-services/QnAMaker/Quickstarts/create-new-kb-nodejs.md
@@ -34,7 +34,7 @@ Visual Studio と Node.js について詳しくは、「[クイック スター�
 
 ## <a name="create-knowledge-base"></a>ナレッジ ベースを作成する
 
-次のコードでは、[Create](https://westus.dev.cognitive.microsoft.com/docs/services/5a93fcf85b4ccd136866eb37/operations/5ac266295b4ccd1554da75ff) メソッドを利用し、新しいサポート技術情報が作成されます。
+次のコードでは、[Create](https://westus.dev.cognitive.microsoft.com/docs/services/5a93fcf85b4ccd136866eb37/operations/5ac266295b4ccd1554da75ff) メソッドを利用し、新しいナレッジ ベースが作成されます。
 
 1. 好みの IDE で新しい Node.js プロジェクトを作成します。
 2. 次に示すコードを追加します。

--- a/articles/cognitive-services/QnAMaker/Quickstarts/create-new-kb-python.md
+++ b/articles/cognitive-services/QnAMaker/Quickstarts/create-new-kb-python.md
@@ -34,7 +34,7 @@ Visual Studio と Python について詳しくは、「[Windows 上の Visual St
 
 ## <a name="create-knowledge-base"></a>ナレッジ ベースを作成する
 
-次のコードでは、[Create](https://westus.dev.cognitive.microsoft.com/docs/services/5a93fcf85b4ccd136866eb37/operations/5ac266295b4ccd1554da75ff) メソッドを利用し、新しいサポート技術情報が作成されます。
+次のコードでは、[Create](https://westus.dev.cognitive.microsoft.com/docs/services/5a93fcf85b4ccd136866eb37/operations/5ac266295b4ccd1554da75ff) メソッドを利用し、新しいナレッジ ベースが作成されます。
 
 1. 適切な IDE で新しい Python プロジェクトを作成します。
 2. 次に示すコードを追加します。

--- a/articles/cognitive-services/QnAMaker/Quickstarts/update-kb-go.md
+++ b/articles/cognitive-services/QnAMaker/Quickstarts/update-kb-go.md
@@ -190,7 +190,7 @@ Press any key to continue.
 
 ## <a name="get-request-status"></a>要求の状態を取得する
 
-[Operation](https://westus.dev.cognitive.microsoft.com/docs/services/5a93fcf85b4ccd136866eb37/operations/operations_getoperationdetails) メソッドを呼び出し、サポート技術情報の作成または更新要求の状態を確認できます。 このメソッドの使われ方を確認するには、[Create](#Create) または [Update](#Update) メソッドのサンプル コードを参照してください。
+[Operation](https://westus.dev.cognitive.microsoft.com/docs/services/5a93fcf85b4ccd136866eb37/operations/operations_getoperationdetails) メソッドを呼び出し、ナレッジ ベースの作成または更新要求の状態を確認できます。 このメソッドの使われ方を確認するには、[Create](#Create) または [Update](#Update) メソッドのサンプル コードを参照してください。
 
 ## <a name="next-steps"></a>次の手順
 


### PR DESCRIPTION
same as #578
original: 'knowledge base'
before: 'サポート技術情報'
after: 'ナレッジ ベース'