### PR TITLE
Fix nonunified

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/toc.yml
+++ b/articles/cognitive-services/Custom-Vision-Service/toc.yml
@@ -8,11 +8,11 @@ items:
   items:
   - name: Custom Vision Service を使い始める
     items:
-    - name: 分類器の構築
+    - name: 分類子の構築
       href: getting-started-build-a-classifier.md
     - name: モデルのテスト
       href: test-your-model.md
-    - name: 分類器の改善
+    - name: 分類子の改善
       href: getting-started-improving-your-classifier.md
     - name: 予測 API の使用
       href: use-prediction-api.md


### PR DESCRIPTION
There are several notations as follows. variants: "分類器" and "分類子".
refs: ![refs](https://user-images.githubusercontent.com/1207985/46510509-61644680-c884-11e8-99b1-9c47ae8a9020.jpg)

In accordance with the following points, we unified it into "分類子".
refs: https://github.com/MicrosoftDocs/azure-docs.ja-jp/pull/750#issuecomment-426763727