### PR TITLE
Fix nonunified

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/use-prediction-api.md
+++ b/articles/cognitive-services/Custom-Vision-Service/use-prediction-api.md
@@ -1,6 +1,6 @@
 ---
 title: Custom Vision Service の予測エンドポイントを使用する - Azure Cognitive Services | Microsoft Docs
-description: API を使用して、Custom Vision Service の分類器によるイメージのテストをプログラムから行う方法を説明します。
+description: API を使用して、Custom Vision Service の分類子によるイメージのテストをプログラムから行う方法を説明します。
 services: cognitive-services
 author: anrothMSFT
 manager: corncar
@@ -16,7 +16,7 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 08/31/2018
 ms.locfileid: "43341795"
 ---
-# <a name="use-the-prediction-endpoint-to-test-images-programmatically-with-a-custom-vision-service-classifier"></a>予測エンドポイントを利用し、Custom Vision Service の分類器を使用してプログラムからイメージをテストします
+# <a name="use-the-prediction-endpoint-to-test-images-programmatically-with-a-custom-vision-service-classifier"></a>予測エンドポイントを利用し、Custom Vision Service の分類子を使用してプログラムからイメージをテストします
 
 モデルをトレーニングした後、イメージを Prediction API に送信することで、プログラムからイメージをテストできます。 
 


### PR DESCRIPTION
There are several notations as follows. variants: "分類器" and "分類子".
refs: ![evi](https://user-images.githubusercontent.com/1207985/46842049-4e162580-ce06-11e8-8261-cc7eb36436f8.jpg)


In accordance with the following points, I unified it into "分類子".
refs: #750 (comment)