### PR TITLE
Fix nonunified

### DIFF
--- a/articles/cognitive-services/Custom-Vision-Service/rest-api-tutorial.md
+++ b/articles/cognitive-services/Custom-Vision-Service/rest-api-tutorial.md
@@ -36,7 +36,7 @@ Custom Vision REST API を使用してモデルを作成、トレーニング、
 
 * bash (Bourne Again Shell) と [curl](https://curl.haxx.se) ユーティリティ、または Windows PowerShell 3.0 (以上)。
 
-* Custom Vision アカウント。 詳細については、「[分類器の構築](getting-started-build-a-classifier.md)」ドキュメントを参照してください。
+* Custom Vision アカウント。 詳細については、「[分類子の構築](getting-started-build-a-classifier.md)」ドキュメントを参照してください。
 
 ## <a name="get-keys"></a>キーの取得
 


### PR DESCRIPTION
There are several notations as follows. variants: "分類器" and "分類子".
refs: ![evi](https://user-images.githubusercontent.com/1207985/46842214-5884ef00-ce07-11e8-9e17-be9ab5235492.jpg)

In accordance with the following points, I unified it into "分類子".
refs: #750 (comment)