### PR TITLE
Fix nonunified

### DIFF
--- a/articles/devops-project/toc.yml
+++ b/articles/devops-project/toc.yml
@@ -1,4 +1,4 @@
-- name: Azure DevOps Projects のドキュメント
+- name: Azure DevOps プロジェクト のドキュメント
   href: index.yml
 - name: 概要
   items:


### PR DESCRIPTION
There are several notations as follows. variants: "Azure DevOps プロジェクト" and "Azure DevOps Projects". So, I unified it into "Azure DevOps プロジェクト".