### PR TITLE
Fix typo & translate

### DIFF
--- a/articles/hdinsight/hadoop/apache-hadoop-develop-deploy-java-mapreduce-linux.md
+++ b/articles/hdinsight/hadoop/apache-hadoop-develop-deploy-java-mapreduce-linux.md
@@ -253,7 +253,7 @@ Java と JDK をインストールするときに、次のような環境変数�
    scp target/wordcountjava-1.0-SNAPSHOT.jar USERNAME@CLUSTERNAME-ssh.azurehdinsight.net:
    ```
 
-    Replace __USERNAME__ with your SSH user name for the cluster. Replace __CLUSTERNAME__ with the HDInsight cluster name.
+__USERNAME__ を SSH ユーザー名に置き換えます。 __CLUSTERNAME__ を HDInsight クラスター名に置き換えます。
 
 このコマンドにより、ファイルがローカル システムからヘッド ノードにコピーされます。 詳細については、[HDInsight での SSH の使用](../hdinsight-hadoop-linux-use-ssh-unix.md)に関するページを参照してください。
 


### PR DESCRIPTION
* Issue1: Originally, the display is incorrect because there is an indent by unnecessary one-byte space in the part which must be "Replace USERNAME with your SSH user name for the cluster. Replace CLUSTERNAME with the HDInsight cluster name."
* Issue2: When the above problem is solved, I translated it because it is strange as it is in English.