### PR TITLE
Improve translation

### DIFF
--- a/articles/terraform/index.yml
+++ b/articles/terraform/index.yml
@@ -9,7 +9,7 @@ documentType: LandingData
 title: Azure 上の Terraform のドキュメント
 metadata:
   title: Azure 上の Terraform のドキュメント - チュートリアル、サンプル、リファレンス、リソース
-  description: Terraform を使用して、Azure 上の仮想マシンやその他のインフラストラクチャを確実にプロビジョニングする方法について説明します。
+  description: Terraform を使用して、Azure 上で仮想マシンやその他のインフラストラクチャを確実にプロビジョニングする方法を学びます。
   services: terraform
   ms.service: terraform
   keywords: Terraform, Azure, DevOps, チュートリアル, サンプル, リファレンス
@@ -19,7 +19,7 @@ metadata:
   ms.topic: landing-page
   ms.date: 08/31/2018
 abstract:
-  description: Terraform を使用すると、Azure 上で確実にインフラストラクチャのバージョン管理と作成を行うことができます。 Microsoft が提供するクイックスタートとチュートリアルを使用して、リソースの作成、Azure Terraform モジュールの使用、インフラストラクチャの管理をコードで行う方法を確認します。
+  description: Terraform を使用して、Azure 上で確実にインフラストラクチャのバージョン管理と作成を行います。 Microsoft が提供するクイックスタートとチュートリアルを使用して、リソースの作成、Azure Terraform モジュールの使用、インフラストラクチャの管理をコードで行う方法を学びます。
 sections:
 - title: クイック スタート
   items:


### PR DESCRIPTION
* diff 12 line
  * In English, it is written as follows.
    * `Learn how to use Terraform to reliably provision virtual machines and other infrastructure on Azure.`
  * In Japanese, it is written as follows.
    * `Terraform を使用して、Azure 上の仮想マシンやその他のインフラストラクチャを確実にプロビジョニングする方法について説明します。`
  * `Learn how to -` says we are in Japanese ` - を学びます` or ` - を学習します`. we do not say ` - を説明します`.
* diff 22 line
  * In English, it is written as follows.
    * `Use Terraform to reliably version and create infrastructure on Azure. Learn how to create resources, use Azure Terraform modules, and maintain your infrastructure with code using our Quickstarts and tutorials.`
  * In Japanese, it is written as follows.
    * `Terraform を使用して、Azure 上で確実にインフラストラクチャのバージョン管理と作成を行います。 Microsoft が提供するクイックスタートとチュートリアルを使用して、リソースの作成、Azure Terraform モジュールの使用、インフラストラクチャの管理をコードで行う方法を学びます。`
  * `Terraform を使用すると` means that we can not do it unless we use Terraform in Japanese. But such an intention is not in the original English. So, as with line 12 `Terraform を使用して` is correct.
  * `行うことができます。` means whether it is possible or not in Japanese. Basically `行うことができます。` in Japanese, `can` is used in the original sentence. But such an intention is not in the original English. Therefore `行います。` is correct.
  * `Learn how to -` says we are in Japanese ` - を学びます` or ` - を学習します`. we do not say ` - を説明します`.
