### PR TITLE
Fix typo

### DIFF
--- a/articles/redis-cache/TOC.yml
+++ b/articles/redis-cache/TOC.yml
@@ -69,7 +69,7 @@ items:
       href: cache-aspnet-session-state-provider.md
     - name: 出力キャッシュ プロバイダー
       href: cache-aspnet-output-cache-provider.md
-  - name: '[管理]'
+  - name: 管理
     items:
     - name: Azure Portal での構成
       href: cache-configure.md
@@ -117,7 +117,7 @@ items:
     href: http://redis.io/clients
   - name: Redis コマンド
     href: http://redis.io/commands#
-  - name: REST ()
+  - name: REST
     href: https://docs.microsoft.com/rest/api/redis/
 - name: リソース
   items:


### PR DESCRIPTION
* I look at [English documents](https://docs.microsoft.com/en-us/azure/redis-cache/cache-redis-cache-arm-provision). But it is not `[Manage]`, `REST ()`. So [], () is unnecessary.