### PR TITLE
Fix typo

### DIFF
--- a/articles/service-fabric-mesh/index.yml
+++ b/articles/service-fabric-mesh/index.yml
@@ -6,9 +6,9 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 09/25/2018
 ms.locfileid: "47158192"
 documentType: LandingData
-title: Azure Service Fabric mesh のドキュメント
+title: Azure Service Fabric Mesh のドキュメント
 metadata:
-  title: Azure Service Fabric mesh のドキュメント - チュートリアル、API リファレンス | Microsoft Docs
+  title: Azure Service Fabric Mesh のドキュメント - チュートリアル、API リファレンス | Microsoft Docs
   meta.description: Azure Service Fabric Mesh is a fully managed service enabling developers to deploy containerized applications without managing virtual machines, storage, or networking resources. Learn how to use Service Fabric Mesh with our quickstarts and tutorials.
   services: service-fabric-mesh
   author: rwike77
@@ -20,22 +20,22 @@ metadata:
   ms.date: 07/26/2018
   ms.author: ryanwi
 abstract:
-  description: Azure Service Fabric mesh は、開発者がインフラストラクチャを管理することなくミッション クリティカルなアプリケーションをビルドしてデプロイできるようにするフル マネージド サービスです。  Service Fabric mesh を使用すると、オンデマンドでスケーリングされる安全な分散型のマイクロサービス アプリケーションをビルドして実行できます。 Microsoft が提供するクイック スタートやチュートリアルを使用して、Service Fabric mesh の使用方法を確認してください。  詳細については、<a href="/azure/service-fabric-mesh/service-fabric-mesh-overview">Service Fabric mesh の概要</a>に関するページを参照してください。
+  description: Azure Service Fabric Mesh は、開発者がインフラストラクチャを管理することなくミッション クリティカルなアプリケーションをビルドしてデプロイできるようにするフル マネージド サービスです。  Service Fabric Mesh を使用すると、オンデマンドでスケーリングされる安全な分散型のマイクロサービス アプリケーションをビルドして実行できます。 Microsoft が提供するクイック スタートやチュートリアルを使用して、Service Fabric mesh の使用方法を確認してください。  詳細については、<a href="/azure/service-fabric-mesh/service-fabric-mesh-overview">Service Fabric Mesh の概要</a>に関するページを参照してください。
 sections:
 - title: 5 分間のクイック スタート
   items:
   - type: paragraph
-    text: Service Fabric アプリケーションとコンテナーを Service Fabric mesh にデプロイする方法について説明します。
+    text: Service Fabric アプリケーションとコンテナーを Service Fabric Mesh にデプロイする方法について説明します。
   - type: list
     style: icon48
     items:
     - image:
         src: https://docs.microsoft.com/media/common/i_cligeneric.svg
-      text: Service Fabric mesh に Hello World をデプロイする
+      text: Service Fabric Mesh に Hello World をデプロイする
       href: /azure/service-fabric-mesh/service-fabric-mesh-quickstart-deploy-container
     - image:
         src: https://docs.microsoft.com/media/logos/logo_netcore.svg
-      text: Web アプリを作成して Service Fabric mesh にデプロイする
+      text: Web アプリを作成して Service Fabric Mesh にデプロイする
       href: /azure/service-fabric-mesh/service-fabric-mesh-quickstart-dotnet-core
 - title: ステップバイステップのチュートリアル
   items:
@@ -52,5 +52,5 @@ sections:
     style: cards
     className: cardsD
     items:
-    - title: REST ()
+    - title: REST
       html: <p><a href="/rest/api/servicefabric/sfmeshrp-index">Service Fabric Mesh リソース プロバイダーの API</a></p><p><a href="/rest/api/servicefabric/sfclient-index#service-fabric-resource-model">Service Fabric クライアント リソースの API</a></p>


### PR DESCRIPTION
* Typo
  * Azure Service Fabric mesh -> Azure Service Fabric Mesh
  * I look at [English documents](https://github.com/MicrosoftDocs/azure-docs/tree/master/articles/service-fabric-mesh/index.yml). But it is not `REST ()`. So () is unnecessary.