### PR TITLE
Improve translation

### DIFF
--- a/articles/marketplace/cloud-partner-portal-orig/cloud-partner-portal-create-iot-edge-module-offer.md
+++ b/articles/marketplace/cloud-partner-portal-orig/cloud-partner-portal-create-iot-edge-module-offer.md
@@ -96,7 +96,7 @@ ms.locfileid: "48807226"
 
 #### <a name="iot-edge-module-metadata-and-the-container-registry"></a>IoT Edge モジュール メタデータとコンテナー レジストリ
 
-IoT Edge モジュールのメタデータには、Azure コンテナー レジストリ (ACR) に格納されているイメージ参照情報が含まれています。 Azure Marketplace によってイメージがパブリック マーケットプレース レジストリにコピーされ、認定後に顧客向けに利用可能になります。 IoT Edge モジュール イメージを使用するためのすべてのユーザー要求は、Marketplace コンテナー レジストリで処理されます。
+IoT Edge モジュールのメタデータには、Azure Container Registry (ACR) に格納されているイメージ参照情報が含まれています。 Azure Marketplace によってイメージがパブリック マーケットプレース レジストリにコピーされ、認定後に顧客向けに利用可能になります。 IoT Edge モジュール イメージを使用するためのすべてのユーザー要求は、Marketplace コンテナー レジストリで処理されます。
 
 ![コンテナー イメージ](./media/cloud-partner-portal-create-iot-edge-module-offer/container-images.png)
 


### PR DESCRIPTION
refs #841

@LisandroSu wrote: https://github.com/MicrosoftDocs/azure-docs.ja-jp/pull/841#issuecomment-433971376

If "この "container registry" は Azure サービス "Azure Container Registry" の名称自体を指すのではなく、ユーザーが作成する個々のレジストリを指しています。" is correct, I think that it is strange to write "Azure コンテナー レジストリ (ACR)" in file. Because "ACR" is an abbreviation for "Azure Container Registry", it is not "ユーザーが作成する個々のレジストリ". Could you confirm it again?