### PR TITLE
Fix unnecessary translation

### DIFF
--- a/articles/azure-monitor/toc.yml
+++ b/articles/azure-monitor/toc.yml
@@ -9,7 +9,7 @@ items:
     href: azure-monitor-rebrand.md
 - name: クイック スタート
   items:
-  - name: '[アプリケーション]'
+  - name: アプリケーション
     items:
     - name: .NET アプリケーション
       href: ../application-insights/quick-monitor-portal.md?toc=/azure/azure-monitor/toc.json
@@ -154,7 +154,7 @@ items:
         href: platform/roles-permissions-security.md
       - name: ワークスペース
         href: platform/manage-access.md
-      - name: '[アプリケーション]'
+      - name: アプリケーション
         href: ../application-insights/app-insights-resources-roles-access-control.md?toc=/azure/azure-monitor/toc.json
       - name: IP アドレス
         href: ../application-insights/app-insights-ip-addresses.md?toc=/azure/azure-monitor/toc.json
@@ -642,7 +642,7 @@ items:
       items:
       - name: ログ
         href: platform/dashboards.md
-      - name: '[アプリケーション]'
+      - name: アプリケーション
         href: ../application-insights/app-insights-dashboards.md?toc=/azure/azure-monitor/toc.json
     - name: Power BI
       items:
@@ -849,7 +849,7 @@ items:
         href: ../monitoring-and-diagnostics/insights-powershell-samples.md?toc=/azure/azure-monitor/toc.json
       - name: PowerShell コマンドレット
         href: platform/powershell-workspace-configuration.md
-      - name: '[アプリケーション]'
+      - name: アプリケーション
         items:
         - name: Application Insights リソースの作成
           href: ../application-insights/app-insights-powershell.md?toc=/azure/azure-monitor/toc.json
@@ -869,7 +869,7 @@ items:
         href: platform/rest-api-walkthrough.md
       - name: アラート API
         href: platform/api-alerts.md
-    - name: '[アプリケーション]'
+    - name: アプリケーション
       items:
       - name: Microsoft Flow での自動化
         href: ../application-insights/app-insights-automate-with-flow.md?toc=/azure/azure-monitor/toc.json
@@ -879,7 +879,7 @@ items:
         href: ../application-insights/automate-custom-reports.md?toc=/azure/azure-monitor/toc.json
   - name: Extend
     items:
-    - name: '[アプリケーション]'
+    - name: アプリケーション
       items:
       - name: カスタム イベントとメトリックの API
         href: ../application-insights/app-insights-api-custom-events-metrics.md?toc=/azure/azure-monitor/toc.json


### PR DESCRIPTION
* Unnecessary translation
  * refs: https://github.com/MicrosoftDocs/azure-docs/blob/master/articles/azure-monitor/toc.yml
  * en: `- name: Applications`, so `[`, `]` unnecessary.