### PR TITLE
Fix typo and fix indents and fix display collapse

### DIFF
--- a/articles/cognitive-services/Content-Moderator/ecommerce-retail-catalog-moderation.md
+++ b/articles/cognitive-services/Content-Moderator/ecommerce-retail-catalog-moderation.md
@@ -185,6 +185,7 @@ Content Moderator にサインアップしてチームを作成する方法に�
 
 1. 前述のセクションでは、成人とわいせつ (Content Moderator)、有名人 (Computer Vision)、旗 (Custom Vision) について受信画像をスキャンしました。
 2. 各スキャンの一致しきい値に基づいて、微妙な場合にレビュー ツールで人がレビューできるようにします。
+
         public static bool CreateReview(string ImageUrl, KeyValuePair[] Metadata) {
 
             ReviewCreationRequest Review = new ReviewCreationRequest();
@@ -207,7 +208,10 @@ Content Moderator にサインアップしてチームを作成する方法に�
 
 1. このチュートリアルでは、画像 URL のリストが記載されたテキスト ファイルが "C:Test" ディレクトリにあるとします。
 2. 次のコードは、ファイルの存在をチェックし、すべての URL をメモリに読み込みます。
-            // Check for a test directory for a text file with the list of Image URLs to scan var topdir = @"C:\test\"; var Urlsfile = topdir + "Urls.txt";
+
+            // Check for a test directory for a text file with the list of Image URLs to scan
+            var topdir = @"C:\test\";
+            var Urlsfile = topdir + "Urls.txt";
 
             if (!Directory.Exists(topdir))
                 return;
@@ -224,7 +228,12 @@ Content Moderator にサインアップしてチームを作成する方法に�
 
 1. このトップレベル関数では、前述のテキスト ファイルに含まれるすべての画像 URL がループ処理されます。
 2. 画像 URL は各 API でスキャンされ、一致信頼度スコアが基準に該当する場合、ヒューマン モデレーター用のレビューが作成されます。
-            // for each image URL in the file... foreach (var Url in Urls) { // Initiatize a new review tags array ReviewTags = new KeyValuePair[MAXTAGSCOUNT];
+
+            // for each image URL in the file...
+            foreach (var Url in Urls)
+            {
+                // Initiatize a new review tags array
+                ReviewTags = new KeyValuePair[MAXTAGSCOUNT];
 
                 // Evaluate for potential adult and racy content with Content Moderator API
                 EvaluateAdultRacy(Url, ref ReviewTags);

--- a/articles/cognitive-services/Content-Moderator/ecommerce-retail-catalog-moderation.md
+++ b/articles/cognitive-services/Content-Moderator/ecommerce-retail-catalog-moderation.md
@@ -66,7 +66,7 @@ Content Moderator にサインアップしてチームを作成する方法に�
 > [!NOTE]
 > このチュートリアルは、次のエンドポイントで表示できるリージョンのサブスクリプション キーを使用するように設計されています。 実際の API キーとリージョン キーを一致させてください。そうしないと、次のエンドポイントではお使いのキーが機能しない可能性があります。
 
-         // Your API keys
+        // Your API keys
         public const string ContentModeratorKey = "XXXXXXXXXXXXXXXXXXXX";
         public const string ComputerVisionKey = "XXXXXXXXXXXXXXXXXXXX";
         public const string CustomVisionKey = "XXXXXXXXXXXXXXXXXXXX";
@@ -128,11 +128,11 @@ Content Moderator にサインアップしてチームを作成する方法に�
 4. ログインするには、使用できるインターネット アカウントのリストから選択します。
 5. サービス ページに表示される API キーをメモします。
     
-   ![Computer Vision API キー](images/tutorial-computer-vision-keys.PNG)
+    ![Computer Vision API キー](images/tutorial-computer-vision-keys.PNG)
     
 6. Computer Vision API を使用して画像をスキャンする関数のプロジェクト ソース コードを参照してください。
 
-         public static bool EvaluateComputerVisionTags(string ImageUrl, string ComputerVisionUri, string ComputerVisionKey, ref KeyValuePair[] ReviewTags)
+        public static bool EvaluateComputerVisionTags(string ImageUrl, string ComputerVisionUri, string ComputerVisionKey, ref KeyValuePair[] ReviewTags)
         {
             var File = ImageUrl;
             string Body = $"{{\"URL\":\"{File}\"}}";
@@ -149,7 +149,7 @@ Content Moderator にサインアップしてチームを作成する方法に�
                 ComputerVisionPrediction CVObject = JsonConvert.DeserializeObject<ComputerVisionPrediction>(Response.Content.ReadAsStringAsync().Result);
 
                 if ((CVObject.categories[0].detail != null) && (CVObject.categories[0].detail.celebrities.Count() > 0))
-                {                 
+                {
                     ReviewTags[2].Value = "true";
                 }
             }
@@ -161,7 +161,7 @@ Content Moderator にサインアップしてチームを作成する方法に�
 
 1. [Custom Vision API プレビュー](https://www.customvision.ai/)に[サインイン](https://azure.microsoft.com/services/cognitive-services/custom-vision-service/)します。
 2. [クイック スタート](https://docs.microsoft.com/azure/cognitive-services/custom-vision-service/getting-started-build-a-classifier)を使用して、旗、おもちゃ、ペンが存在する可能性があるコンテンツを検出するカスタム分類子を構築します。
-   ![Custom Vision のトレーニング画像](images/tutorial-ecommerce-custom-vision.PNG)
+    ![Custom Vision のトレーニング画像](images/tutorial-ecommerce-custom-vision.PNG)
 3. カスタム分類子の[予測エンドポイント URL を取得します](https://docs.microsoft.com/azure/cognitive-services/custom-vision-service/use-prediction-api)。
 4. 画像をスキャンするためにカスタム分類子の予測エンドポイントを呼び出す関数については、プロジェクトのソース コードを参照してください。
 
@@ -179,7 +179,7 @@ Content Moderator にサインアップしてチームを作成する方法に�
                 SaveCustomVisionTags(response.Content.ReadAsStringAsync().Result, ref ReviewTags);
             }
             return response.IsSuccessStatusCode;
-        }       
+        }
  
 ## <a name="reviews-for-human-in-the-loop"></a>human-in-the-loop (人間参加) のレビュー
 
@@ -224,7 +224,7 @@ Content Moderator にサインアップしてチームを作成する方法に�
 
 1. このトップレベル関数では、前述のテキスト ファイルに含まれるすべての画像 URL がループ処理されます。
 2. 画像 URL は各 API でスキャンされ、一致信頼度スコアが基準に該当する場合、ヒューマン モデレーター用のレビューが作成されます。
-             // for each image URL in the file... foreach (var Url in Urls) { // Initiatize a new review tags array ReviewTags = new KeyValuePair[MAXTAGSCOUNT];
+            // for each image URL in the file... foreach (var Url in Urls) { // Initiatize a new review tags array ReviewTags = new KeyValuePair[MAXTAGSCOUNT];
 
                 // Evaluate for potential adult and racy content with Content Moderator API
                 EvaluateAdultRacy(Url, ref ReviewTags);

--- a/articles/cognitive-services/Content-Moderator/ecommerce-retail-catalog-moderation.md
+++ b/articles/cognitive-services/Content-Moderator/ecommerce-retail-catalog-moderation.md
@@ -249,4 +249,4 @@ Content Moderator にサインアップしてチームを作成する方法に�
 
 ## <a name="next-steps"></a>次の手順
 
-Github の[プロジェクト ソース ファイル](https://github.com/MicrosoftContentModerator/samples-eCommerceCatalogModeration)を使用して、チュートリアルを構築し、拡張します。
+GitHub の[プロジェクト ソース ファイル](https://github.com/MicrosoftContentModerator/samples-eCommerceCatalogModeration)を使用して、チュートリアルを構築し、拡張します。


### PR DESCRIPTION
* Fix typo: Github -> GitHub
* Fix indents: Indent was out of alignment
* Fix display collapse: The content of the article was already different from the latest version of the English version. So, I'm restoring from the article of the time when this was written.
  * evi1![evi1](https://user-images.githubusercontent.com/1207985/50138178-0cf83100-02e1-11e9-98ed-9fb847fb29c0.jpg)
  * evi2![evi2](https://user-images.githubusercontent.com/1207985/50138176-0c5f9a80-02e1-11e9-9bee-331e455d68d8.jpg)
  * evi3![evi3](https://user-images.githubusercontent.com/1207985/50138177-0c5f9a80-02e1-11e9-9896-4553c260c5e6.jpg)



