### PR TITLE
Translation translation omission

### DIFF
--- a/articles/data-factory/concepts-pipelines-activities.md
+++ b/articles/data-factory/concepts-pipelines-activities.md
@@ -21,7 +21,7 @@ ms.lasthandoff: 08/27/2018
 ms.locfileid: "43109441"
 ---
 # <a name="pipelines-and-activities-in-azure-data-factory"></a>Azure Data Factory のパイプラインとアクティビティ
-> [!div class="op_single_selector" title1="使用しているData Factoryサービスのバージョンを選択してください:"]
+> [!div class="op_single_selector" title1="使用している Data Factory サービスのバージョンを選択してください:"]
 > * [Version 1](v1/data-factory-create-pipelines.md)
 > * [現在のバージョン](concepts-pipelines-activities.md)
 

--- a/articles/data-factory/concepts-pipelines-activities.md
+++ b/articles/data-factory/concepts-pipelines-activities.md
@@ -21,7 +21,7 @@ ms.lasthandoff: 08/27/2018
 ms.locfileid: "43109441"
 ---
 # <a name="pipelines-and-activities-in-azure-data-factory"></a>Azure Data Factory のパイプラインとアクティビティ
-> [!div class="op_single_selector" title1="Select the version of Data Factory service you are using:"]
+> [!div class="op_single_selector" title1="使用しているData Factoryサービスのバージョンを選択してください:"]
 > * [Version 1](v1/data-factory-create-pipelines.md)
 > * [現在のバージョン](concepts-pipelines-activities.md)
 


### PR DESCRIPTION
This fix was rejected as `Source Issue` in #1426 and #1431 was issued.
However, #1428 which is a modification of the same translation in another file could be merged.
In addition, as we can see below, I think that this is not `Source Issue`, but translation leakage.
![evi](https://user-images.githubusercontent.com/1207985/50499721-35c1b880-0a8f-11e9-8aa5-d8eeded2392e.jpg)