### PR TITLE
Delete unnecessary brackets

### DIFF
--- a/articles/active-directory-b2c/predicates.md
+++ b/articles/active-directory-b2c/predicates.md
@@ -1,5 +1,5 @@
 ---
-title: 述語および PredicateValidations - Azure Active Directory B2C | Microsoft Docs
+title: Predicates および PredicateValidations - Azure Active Directory B2C | Microsoft Docs
 description: Azure Active Directory B2C の Identity Experience Framework スキーマのソーシャル アカウント要求変換の例。
 services: active-directory-b2c
 author: davidmu1
@@ -17,32 +17,32 @@ ms.contentlocale: ja-JP
 ms.lasthandoff: 09/28/2018
 ms.locfileid: "47432173"
 ---
-# <a name="predicates-and-predicatevalidations"></a>述語および PredicateValidations
+# <a name="predicates-and-predicatevalidations"></a>Predicates および PredicateValidations
 
 [!INCLUDE [active-directory-b2c-advanced-audience-warning](../../includes/active-directory-b2c-advanced-audience-warning.md)]
 
-**述語**と **PredicateValidations** 要素を使用して検証プロセスを実行し、適切に形式設定されたデータのみが Azure Active Directory (Azure AD) B2C テナントに入力されるようにすることができます。
+**Predicates**と **PredicateValidations** 要素を使用して検証プロセスを実行し、適切に形式設定されたデータのみが Azure Active Directory (Azure AD) B2C テナントに入力されるようにすることができます。
 
 次の図に、要素の関係を示します。
 
 ![述語](./media/predicates/predicates.png)
 
-## <a name="predicates"></a>述語
+## <a name="predicates"></a>Predicates
 
-**述語**要素によって、要求タイプの値をチェックする基本的な検証が定義され、`true` または `false` が返されます。 検証は、指定された **Method** 要素と、そのメソッドに関連する **Parameter** 要素のセットを使用して行われます。 例えば、述語によって、文字列要求値の長さが、指定された最小および最大パラメーターの範囲内にあるかどうか、または文字列要求の値に文字セットが含まれているかどうかをチェックできます。 **UserHelpText** 要素により、チェックが失敗した場合にユーザーに表示されるエラー メッセージが指定されます。 **UserHelpText** 要素の値を、[言語のカスタマイズ](localization.md)を使用してローカライズできます。
+**Predicate**要素によって、要求タイプの値をチェックする基本的な検証が定義され、`true` または `false` が返されます。 検証は、指定された **Method** 要素と、そのメソッドに関連する **Parameter** 要素のセットを使用して行われます。 例えば、述語によって、文字列要求値の長さが、指定された最小および最大パラメーターの範囲内にあるかどうか、または文字列要求の値に文字セットが含まれているかどうかをチェックできます。 **UserHelpText** 要素により、チェックが失敗した場合にユーザーに表示されるエラー メッセージが指定されます。 **UserHelpText** 要素の値を、[言語のカスタマイズ](localization.md)を使用してローカライズできます。
 
 **Predicates** 要素には、次の要素が含まれています。
 
 | 要素 | 発生回数 | 説明 |
 | ------- | ----------- | ----------- |
-| 述語 | 1:n | 述語の一覧。 |
+| Predicate | 1:n | 述語の一覧。 |
 
 **Predicate** 要素には、次の属性が含まれています。
 
 | Attribute | 必須 | 説明 |
 | --------- | -------- | ----------- |
-| ID | はい | 述語に使用される識別子です。 その他の要素は、ポリシーでこの識別子を使用することができます。 |
-| 方法 | はい | 検証に使用するメソッドの型。 使用可能な値: **IsLengthRange**、**MatchesRegex**、**IncludesCharacters**、または **IsDateRange**。 **IsLengthRange** 値によって、文字列要求値の長さが、指定された最小および最大パラメーターの範囲内にあるかどうかがチェックされます。 **MatchesRegex** 値によって、文字列要求値が正規表現に一致するかどうかがチェックされます。 **IncludesCharacters** 値によって、文字列要求値に文字セットが含まれているかどうかがチェックされます。 **IsDateRange** 値によって、日付要求値が、指定された最小および最大パラメーターの範囲内にあるかどうかがチェックされます。 |
+| Id | はい | 述語に使用される識別子です。 その他の要素は、ポリシーでこの識別子を使用することができます。 |
+| Method | はい | 検証に使用するメソッドの型。 使用可能な値: **IsLengthRange**、**MatchesRegex**、**IncludesCharacters**、または **IsDateRange**。 **IsLengthRange** 値によって、文字列要求値の長さが、指定された最小および最大パラメーターの範囲内にあるかどうかがチェックされます。 **MatchesRegex** 値によって、文字列要求値が正規表現に一致するかどうかがチェックされます。 **IncludesCharacters** 値によって、文字列要求値に文字セットが含まれているかどうかがチェックされます。 **IsDateRange** 値によって、日付要求値が、指定された最小および最大パラメーターの範囲内にあるかどうかがチェックされます。 |
 
 **Predicate** 要素には、次の要素が含まれています。
 
@@ -55,13 +55,13 @@ ms.locfileid: "47432173"
 
 | 要素 | 発生回数 | 説明 |
 | ------- | ----------- | ----------- |
-| パラメーター | 1:n | 文字列検証のメソッド タイプのパラメーター。 |
+| Parameter | 1:n | 文字列検証のメソッド タイプのパラメーター。 |
 
 **Parameters** 要素には、次の属性が含まれています。
 
 | 要素 | 発生回数 | 説明 |
 | ------- | ----------- | ----------- |
-| ID | 1:1 | パラメーターの識別子。 |
+| Id | 1:1 | パラメーターの識別子。 |
 
 次の例は、文字列の長さ範囲を指定する `Minimum` および `Maximum` パラメーターを持つ `IsLengthRange` メソッドを示しています。
 
@@ -110,7 +110,7 @@ ms.locfileid: "47432173"
 
 ## <a name="predicatevalidations"></a>PredicateValidations
 
-述語によって、要求タイプに対してチェックを行う検証が定義されますが、**PredicateValidations** は要求タイプに適用できるユーザー入力検証を形式設定する述語セットをグループ化します。 各 **PredicateValidation** 要素には、**Predicate** をポイントする **PredicateReference** 要素のセットを含む **PredicateGroup** 要素のセットが含まれています。 検証に合格するには、要求の値が、**PredicateReference** 要素のセットを持つすべての **PredicateGroup** に基づき、すべての述語のすべてのテストに合格する必要があります。
+predicates によって、要求タイプに対してチェックを行う検証が定義されますが、**PredicateValidations** は要求タイプに適用できるユーザー入力検証を形式設定する述語セットをグループ化します。 各 **PredicateValidation** 要素には、**Predicate** をポイントする **PredicateReference** 要素のセットを含む **PredicateGroup** 要素のセットが含まれています。 検証に合格するには、要求の値が、**PredicateReference** 要素のセットを持つすべての **PredicateGroup** に基づき、すべての述語のすべてのテストに合格する必要があります。
 
 ```XML
 <PredicateValidations>
@@ -140,7 +140,7 @@ ms.locfileid: "47432173"
 
 | Attribute | 必須 | 説明 |
 | --------- | -------- | ----------- |
-| ID | はい | 述語の検証に使用される識別子です。 **ClaimType** 要素は、ポリシーにこの識別子を使用できます。 |
+| Id | はい | 述語の検証に使用される識別子です。 **ClaimType** 要素は、ポリシーにこの識別子を使用できます。 |
 
 **PredicateValidation** 要素には、次の要素が含まれています。
 
@@ -158,7 +158,7 @@ ms.locfileid: "47432173"
 
 | Attribute | 必須 | 説明 |
 | --------- | -------- | ----------- |
-| ID | はい | 述語グループに使用される識別子です。  |
+| Id | はい | 述語グループに使用される識別子です。  |
 
 **PredicateGroups** 要素には、次の要素が含まれています。
 
@@ -183,7 +183,7 @@ ms.locfileid: "47432173"
 
 | Attribute | 必須 | 説明 |
 | --------- | -------- | ----------- |
-| ID | はい | 述語の検証に使用される識別子です。  |
+| Id | はい | 述語の検証に使用される識別子です。  |
 
 
 ## <a name="configure-password-complexity"></a>パスワードの複雑さの構成
@@ -350,9 +350,9 @@ Azure AD B2C にエラー メッセージが表示された場合に、要素が
 
 ![述語のプロセス](./media/predicates/predicates-pass.png)
 
- ## <a name="configure-a-date-range"></a>日付範囲の構成
+## <a name="configure-a-date-range"></a>日付範囲の構成
 
-**Predicates** 要素と **PredicateValidations** 要素を使用して、**UserInputType** の最小および最大日付値を、`DateTimeDropdown` を使用して制御できます。 これを行うには、`IsDateRange` メソッドを使用して**述語**を作成し、最小および最大パラメーターを指定します。
+**Predicates** 要素と **PredicateValidations** 要素を使用して、**UserInputType** の最小および最大日付値を、`DateTimeDropdown` を使用して制御できます。 これを行うには、`IsDateRange` メソッドを使用して **Predicate** を作成し、最小および最大パラメーターを指定します。
 
 ```XML
 <Predicates>

--- a/articles/active-directory-b2c/predicates.md
+++ b/articles/active-directory-b2c/predicates.md
@@ -21,13 +21,13 @@ ms.locfileid: "47432173"
 
 [!INCLUDE [active-directory-b2c-advanced-audience-warning](../../includes/active-directory-b2c-advanced-audience-warning.md)]
 
-**述語**と **PredicateValidations** 要素を使用して検証プロセスを実行し、適切に形式設定されたデータのみが Azure Active Directory (Azure AD) B2C テナントに入力されるようにすることができます。  
+**述語**と **PredicateValidations** 要素を使用して検証プロセスを実行し、適切に形式設定されたデータのみが Azure Active Directory (Azure AD) B2C テナントに入力されるようにすることができます。
 
-次の図に、要素の関係を示します。  
+次の図に、要素の関係を示します。
 
 ![述語](./media/predicates/predicates.png)
 
-## <a name="predicates"></a>述語  
+## <a name="predicates"></a>述語
 
 **述語**要素によって、要求タイプの値をチェックする基本的な検証が定義され、`true` または `false` が返されます。 検証は、指定された **Method** 要素と、そのメソッドに関連する **Parameter** 要素のセットを使用して行われます。 例えば、述語によって、文字列要求値の長さが、指定された最小および最大パラメーターの範囲内にあるかどうか、または文字列要求の値に文字セットが含まれているかどうかをチェックできます。 **UserHelpText** 要素により、チェックが失敗した場合にユーザーに表示されるエラー メッセージが指定されます。 **UserHelpText** 要素の値を、[言語のカスタマイズ](localization.md)を使用してローカライズできます。
 
@@ -35,27 +35,27 @@ ms.locfileid: "47432173"
 
 | 要素 | 発生回数 | 説明 |
 | ------- | ----------- | ----------- |
-| 述語 | 1:n | 述語の一覧。 | 
+| 述語 | 1:n | 述語の一覧。 |
 
 **Predicate** 要素には、次の属性が含まれています。
 
 | Attribute | 必須 | 説明 |
 | --------- | -------- | ----------- |
-| ID | [はい] | 述語に使用される識別子です。 その他の要素は、ポリシーでこの識別子を使用することができます。 |
-| 方法 | [はい] | 検証に使用するメソッドの型。 使用可能な値: **IsLengthRange**、**MatchesRegex**、**IncludesCharacters**、または **IsDateRange**。 **IsLengthRange** 値によって、文字列要求値の長さが、指定された最小および最大パラメーターの範囲内にあるかどうかがチェックされます。 **MatchesRegex** 値によって、文字列要求値が正規表現に一致するかどうかがチェックされます。 **IncludesCharacters** 値によって、文字列要求値に文字セットが含まれているかどうかがチェックされます。 **IsDateRange** 値によって、日付要求値が、指定された最小および最大パラメーターの範囲内にあるかどうかがチェックされます。 |
+| ID | はい | 述語に使用される識別子です。 その他の要素は、ポリシーでこの識別子を使用することができます。 |
+| 方法 | はい | 検証に使用するメソッドの型。 使用可能な値: **IsLengthRange**、**MatchesRegex**、**IncludesCharacters**、または **IsDateRange**。 **IsLengthRange** 値によって、文字列要求値の長さが、指定された最小および最大パラメーターの範囲内にあるかどうかがチェックされます。 **MatchesRegex** 値によって、文字列要求値が正規表現に一致するかどうかがチェックされます。 **IncludesCharacters** 値によって、文字列要求値に文字セットが含まれているかどうかがチェックされます。 **IsDateRange** 値によって、日付要求値が、指定された最小および最大パラメーターの範囲内にあるかどうかがチェックされます。 |
 
 **Predicate** 要素には、次の要素が含まれています。
 
 | 要素 | 発生回数 | 説明 |
 | ------- | ----------- | ----------- |
 | UserHelpText | 1:1 | チェックが失敗した場合に、ユーザーに表示されるエラー メッセージ。 この文字列は、[言語カスタマイズ](localization.md)を使ってローカライズすることができます。 |
-| parameters | 1:1 | 文字列検証のメソッド タイプのパラメーター。 | 
+| parameters | 1:1 | 文字列検証のメソッド タイプのパラメーター。 |
 
 **Parameters** 要素には、次の要素が含まれています。
 
 | 要素 | 発生回数 | 説明 |
 | ------- | ----------- | ----------- |
-| パラメーター | 1:n | 文字列検証のメソッド タイプのパラメーター。 | 
+| パラメーター | 1:n | 文字列検証のメソッド タイプのパラメーター。 |
 
 **Parameters** 要素には、次の属性が含まれています。
 
@@ -108,7 +108,7 @@ ms.locfileid: "47432173"
 </Predicate>
 ```
 
-## <a name="predicatevalidations"></a>PredicateValidations 
+## <a name="predicatevalidations"></a>PredicateValidations
 
 述語によって、要求タイプに対してチェックを行う検証が定義されますが、**PredicateValidations** は要求タイプに適用できるユーザー入力検証を形式設定する述語セットをグループ化します。 各 **PredicateValidation** 要素には、**Predicate** をポイントする **PredicateReference** 要素のセットを含む **PredicateGroup** 要素のセットが含まれています。 検証に合格するには、要求の値が、**PredicateReference** 要素のセットを持つすべての **PredicateGroup** に基づき、すべての述語のすべてのテストに合格する必要があります。
 
@@ -134,38 +134,38 @@ ms.locfileid: "47432173"
 
 | 要素 | 発生回数 | 説明 |
 | ------- | ----------- | ----------- |
-| PredicateValidation | 1:n | 述語検証の一覧。 | 
+| PredicateValidation | 1:n | 述語検証の一覧。 |
 
 **PredicateValidation** 要素には、次の属性が含まれています。
 
 | Attribute | 必須 | 説明 |
 | --------- | -------- | ----------- |
-| ID | [はい] | 述語の検証に使用される識別子です。 **ClaimType** 要素は、ポリシーにこの識別子を使用できます。 |
+| ID | はい | 述語の検証に使用される識別子です。 **ClaimType** 要素は、ポリシーにこの識別子を使用できます。 |
 
 **PredicateValidation** 要素には、次の要素が含まれています。
 
 | 要素 | 発生回数 | 説明 |
 | ------- | ----------- | ----------- |
-| PredicateGroups | 1:n | 述語グループの一覧。 | 
+| PredicateGroups | 1:n | 述語グループの一覧。 |
 
 **PredicateGroups** 要素には、次の要素が含まれています。
 
 | 要素 | 発生回数 | 説明 |
 | ------- | ----------- | ----------- |
-| PredicateGroup | 1:n | 述語の一覧。 | 
+| PredicateGroup | 1:n | 述語の一覧。 |
 
 **PredicateGroups** 要素には、次の属性が含まれています。
 
 | Attribute | 必須 | 説明 |
 | --------- | -------- | ----------- |
-| ID | [はい] | 述語グループに使用される識別子です。  |
+| ID | はい | 述語グループに使用される識別子です。  |
 
 **PredicateGroups** 要素には、次の要素が含まれています。
 
 | 要素 | 発生回数 | 説明 |
 | ------- | ----------- | ----------- |
-| UserHelpText | 1:1 |  ユーザーが入力する必要のある値を把握するのに役立つ、述語の説明。 | 
-| PredicateReferences | 1:n | 述語参照の一覧。 | 
+| UserHelpText | 1:1 |  ユーザーが入力する必要のある値を把握するのに役立つ、述語の説明。 |
+| PredicateReferences | 1:n | 述語参照の一覧。 |
 
 **PredicateReferences** 要素には、次の属性が含まれています。
 
@@ -177,18 +177,18 @@ ms.locfileid: "47432173"
 
 | 要素 | 発生回数 | 説明 |
 | ------- | ----------- | ----------- |
-| PredicateReference | 1:n | 述語への参照。 | 
+| PredicateReference | 1:n | 述語への参照。 |
 
 **PredicateReference** 要素には、次の属性が含まれています。
 
 | Attribute | 必須 | 説明 |
 | --------- | -------- | ----------- |
-| ID | [はい] | 述語の検証に使用される識別子です。  |
+| ID | はい | 述語の検証に使用される識別子です。  |
 
 
 ## <a name="configure-password-complexity"></a>パスワードの複雑さの構成
 
-**Predicates** と **PredicateValidationsInput** を使用して、アカウントを作成するときにユーザーによって指定されるパスワードの複雑さに対する要件を制御できます。 既定では、Azure AD B2C では強力なパスワードが使用されます。 Azure AD B2C では、顧客が使用できるパスワードの複雑さを制御する構成オプションもサポートしています。 これらの述語要素を使用して、パスワードの複雑さを定義できます。 
+**Predicates** と **PredicateValidationsInput** を使用して、アカウントを作成するときにユーザーによって指定されるパスワードの複雑さに対する要件を制御できます。 既定では、Azure AD B2C では強力なパスワードが使用されます。 Azure AD B2C では、顧客が使用できるパスワードの複雑さを制御する構成オプションもサポートしています。 これらの述語要素を使用して、パスワードの複雑さを定義できます。
 
 - **IsLengthBetween8And64**: `IsLengthRange` メソッドを使用して、パスワードが 8 文字から 64 文字の間であることを検証します。
 - **Lowercase**: `IncludesCharacters` メソッドを使用して、パスワードに小文字が含まれていることを検証します。
@@ -381,8 +381,8 @@ Azure AD B2C にエラー メッセージが表示された場合に、要素が
 </PredicateValidations>
 ```
 
-要求の種類で、**PredicateValidationReference** 要素を追加し、`CustomDateRange` に ID を指定します。 
-    
+要求の種類で、**PredicateValidationReference** 要素を追加し、`CustomDateRange` に ID を指定します。
+
 ```XML
 <ClaimType Id="dateOfBirth">
   <DisplayName>Date of Birth</DisplayName>
@@ -392,4 +392,4 @@ Azure AD B2C にエラー メッセージが表示された場合に、要素が
   <UserInputType>DateTimeDropdown</UserInputType>
   <PredicateValidationReference Id="CustomDateRange" />
 </ClaimType>
- ```
+```


### PR DESCRIPTION
Fix unnecessary translation: Because `Attribute` and `Element` are described in XML, it is incorrect to translate into Japanese. 
In this file, `Predicate`,` Predicates` seems to be an element of a program, not a word intended to convert to `述語`. Therefore, when you translate the sentences will lose consistency.