### PR TITLE
Fix unnecessary translation

### DIFF
--- a/articles/active-directory-b2c/TOC.yml
+++ b/articles/active-directory-b2c/TOC.yml
@@ -179,7 +179,7 @@ items:
               href: stringcollection-transformations.md
             - name: String
               href: string-transformations.md
-          - name: 述語
+          - name: Predicates
             href: predicates.md
           - name: ContentDefinitions
             href: contentdefinitions.md


### PR DESCRIPTION
refs: #1466 
Fix unnecessary translation: In this file, `Predicates` seems to be an element of a program, not a word intended to convert to `述語`. Therefore, when you translate the sentences will lose consistency.