### PR TITLE
Fix missing

### DIFF
--- a/articles/app-service/containers/tutorial-python-postgresql-app.md
+++ b/articles/app-service/containers/tutorial-python-postgresql-app.md
@@ -335,7 +335,7 @@ git commit -am "configure for App Service"
 
 チュートリアルの前半で、PostgreSQL データベースに接続する環境変数を定義しました。
 
-App Service では、Cloud Shell で [`az webapp config appsettings set`](/cli/azure/webapp/config/appsettings?view=azure-cli-latest#az-webapp-config-appsettings-set) コマンドを使用し、環境変数を_アプリ設定_として設定します。
+App Service では、Cloud Shell で [`az webapp config appsettings set`](/cli/azure/webapp/config/appsettings?view=azure-cli-latest#az-webapp-config-appsettings-set) コマンドを使用し、環境変数を _アプリ設定_ として設定します。
 
 次の例では、データベース接続の詳細をアプリ設定として指定します。 
 


### PR DESCRIPTION
Since there is no one-byte space around it, it is not in italic notation.