### PR TITLE
Suggest to fix az redis show

### DIFF
--- a/articles/azure-cache-for-redis/scripts/cache-keys-ports.md
+++ b/articles/azure-cache-for-redis/scripts/cache-keys-ports.md
@@ -39,7 +39,7 @@ ms.locfileid: "55754457"
 
 | コマンド | メモ |
 |---|---|
-| [az redis の表示](https://docs.microsoft.com/cli/azure/redis) | Azure Cache for Redis インスタンスの詳細を取得します。 |
+| [az redis show](https://docs.microsoft.com/cli/azure/redis) | Azure Cache for Redis インスタンスの詳細を取得します。 |
 | [az redis list-keys](https://docs.microsoft.com/cli/azure/redis) | Azure Cache for Redis インスタンスのアクセス キーを取得します。 |
 
 

--- a/articles/azure-cache-for-redis/scripts/show-cache.md
+++ b/articles/azure-cache-for-redis/scripts/show-cache.md
@@ -38,7 +38,7 @@ ms.locfileid: "55749161"
 
 | コマンド | メモ |
 |---|---|
-| [az redis の表示](https://docs.microsoft.com/cli/azure/redis) | Azure Cache for Redis インスタンスの詳細を取得します。 |
+| [az redis show](https://docs.microsoft.com/cli/azure/redis) | Azure Cache for Redis インスタンスの詳細を取得します。 |
 
 
 ## <a name="next-steps"></a>次の手順


### PR DESCRIPTION
Commands should be kept in alphabet.