### PR TITLE
fix typo

### DIFF
--- a/articles/active-directory/fundamentals/toc.yml
+++ b/articles/active-directory/fundamentals/toc.yml
@@ -56,7 +56,7 @@ items:
       href: active-directory-groups-delete-group.md
     - name: 他のグループに対するメンバーの追加または削除
       href: active-directory-groups-membership-azure-portal.md
-    - name: グループ情報の編修
+    - name: グループ情報の編集
       href: active-directory-groups-settings-azure-portal.md
     - name: グループ所有者の追加または削除
       href: active-directory-accessmanagement-managing-group-owners.md


### PR DESCRIPTION
「編修」を「編集」に変更

リンク先も「編集」となっている
https://docs.microsoft.com/ja-jp/azure/active-directory/fundamentals/active-directory-groups-settings-azure-portal