### PR TITLE
誤訳の修正

### DIFF
--- a/articles/cosmos-db/table-storage-how-to-use-dotnet.md
+++ b/articles/cosmos-db/table-storage-how-to-use-dotnet.md
@@ -171,7 +171,7 @@ CloudTableClient tableClient = storageAccount.CreateCloudTableClient();
 これで、Table Storage に対してデータの読み取りと書き込みを実行するコードを記述する準備が整いました。
 
 ## <a name="create-a-table"></a>テーブルを作成する
-この例は、テーブルがない場合に、キューを作成する方法を示しています。
+この例は、テーブルがない場合は、作成する方法を示しています。
 
 ```csharp
 // Retrieve the storage account from the connection string.


### PR DESCRIPTION
原文は、下記です。
> This example shows how to create a table if it does not already exist:

翻訳は、「キューを作成する方法」となっていますが。作成するのは、Tableです。「キュー」は関係ありません。