### PR TITLE
Suggest to improve translations

### DIFF
--- a/articles/sql-database/toc.yml
+++ b/articles/sql-database/toc.yml
@@ -173,7 +173,7 @@ items:
       href: sql-database-elastic-pool-manage.md
   - name: マネージド インスタンス
     items:
-    - name: 複数のマネージド インスタンスの概要
+    - name: マネージド インスタンスの概要
       href: sql-database-managed-instance-index.yml
     - name: マネージド インスタンスの機能
       href: sql-database-managed-instance.md


### PR DESCRIPTION
The original text is: 'Managed instances overview'
'instances' is plural, so they use '複数の', I guess.
It doesn't mean multiple.
'複数の' is too much, I think.
