### PR TITLE
Fix mistranslation

### DIFF
--- a/articles/security/blueprints/au-protected-iaaswa-overview.md
+++ b/articles/security/blueprints/au-protected-iaaswa-overview.md
@@ -25,7 +25,7 @@ ms.locfileid: "60610190"
 ASD 準拠を達成するには、Information Security Registered Assessor (情報セキュリティ登録査定官) がシステムを監査する必要があります。 お客様は、このアーキテクチャを使用してビルドしたソリューションの適切なセキュリティとコンプライアンスの評価を実施する責任を負います。要件は、お客様の実装によって変化する可能性があるからです。
 
 ## <a name="architecture-diagram-and-components"></a>アーキテクチャ ダイアグラムとコンポーネント
-このソリューションは、バックエンドに SQL Server を使用する IaaS Web アプリケーション向けのリファレンス アーキテクチャをデプロイします。 アーキテクチャには、Web 層、データ層、Active Directory インフラストラクチャ、Application Gateway、および Load Balancer が含まれています。 Web 層とデータ層にデプロイされる仮想マシンは可用性セット内に構成され、SQL Server インスタンスは高可用性のために Always On 可用性グループ内に構成されます。 仮想マシンはドメインに参加し、Active Directory グループ ポリシーを使用して、オペレーティング システム レベルでセキュリティとコンプライアンスの構成が適用されます。 管理要塞ホストは、デプロイされたリソースにアクセスするためのセキュリティで保護された接続を管理者に提供します。
+このソリューションは、バックエンドに SQL Server を使用する IaaS Web アプリケーション向けのリファレンス アーキテクチャをデプロイします。 アーキテクチャには、Web 層、データ層、Active Directory インフラストラクチャ、Application Gateway、および Load Balancer が含まれています。 Web 層とデータ層にデプロイされる仮想マシンは可用性セット内に構成され、SQL Server インスタンスは高可用性のために Always On 可用性グループ内に構成されます。 仮想マシンはドメインに参加し、Active Directory グループ ポリシーを使用して、オペレーティング システム レベルでセキュリティとコンプライアンスの構成が適用されます。 管理踏み台ホストは、デプロイされたリソースにアクセスするためのセキュリティで保護された接続を管理者に提供します。
 
 このアーキテクチャは、オンプレミスのネットワークを Azure に拡張するセキュリティ保護されたハイブリッド環境を提供できますので、企業ユーザーは、組織のプライベート ローカル エリア ネットワークまたはインターネットから Web ベースのワークロードに安全にアクセスできます。 オンプレミス ソリューションでは、セキュリティ、運用、コンプライアンスのすべての側面についてお客様が責任を持って担当します。
 
@@ -59,7 +59,7 @@ ASD 準拠を達成するには、Information Security Registered Assessor (情�
 - Azure Monitor ログ
 - Azure Storage
 - Azure Virtual Machines
-    - (1) 管理/要塞 (Windows Server 2016 Datacenter)
+    - (1) 管理/踏み台 (Windows Server 2016 Datacenter)
     - (2) SQL Server クラスター ノード (Windows Server 2016 上の SQL Server 2017)
     - (2) Web/IIS (Windows Server 2016 Datacenter)
 - Azure Virtual Network
@@ -72,9 +72,9 @@ ASD 準拠を達成するには、Information Security Registered Assessor (情�
 ## <a name="deployment-architecture"></a>デプロイメント アーキテクチャ
 次のセクションで、デプロイと実装の要素について詳しく説明します。
 
-**要塞ホスト**:要塞ホストは、この環境にデプロイされたリソースへのユーザーのアクセスを許可する単一エントリ ポイントです。 要塞ホストは、セーフ リスト上のパブリック IP アドレスからのリモート トラフィックのみを許可することで、デプロイ済みのリソースへのセキュリティで保護された接続を提供します。 リモート デスクトップ (RDP) トラフィックを許可するには、トラフィックのソースがネットワーク セキュリティ グループに定義されている必要があります。
+**踏み台ホスト**:踏み台ホストは、この環境にデプロイされたリソースへのユーザーのアクセスを許可する単一エントリ ポイントです。 踏み台ホストは、セーフ リスト上のパブリック IP アドレスからのリモート トラフィックのみを許可することで、デプロイ済みのリソースへのセキュリティで保護された接続を提供します。 リモート デスクトップ (RDP) トラフィックを許可するには、トラフィックのソースがネットワーク セキュリティ グループに定義されている必要があります。
 
-このソリューションでは、次の構成を持つドメイン参加済み要塞ホストとして仮想マシンを作成します。
+このソリューションでは、次の構成を持つドメイン参加済み踏み台ホストとして仮想マシンを作成します。
 -   [マルウェア対策拡張機能](https://docs.microsoft.com/azure/security/azure-security-antimalware)
 -   [Azure Diagnostics 拡張機能](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-extensions-diagnostics-template)
 -   Azure Key Vault を使用した [Azure ディスクの暗号化](https://docs.microsoft.com/azure/security/azure-security-disk-encryption)
@@ -89,7 +89,7 @@ ASD 準拠を達成するには、Information Security Registered Assessor (情�
 
 各サブネットには、専用のネットワーク セキュリティ グループがあります。
 - Application Gateway 用の 1 つのネットワーク セキュリティ グループ (LBNSG)
-- 要塞ホスト用の 1 つのネットワーク セキュリティ グループ (MGTNSG)
+- 踏み台ホスト用の 1 つのネットワーク セキュリティ グループ (MGTNSG)
 - SQL Server とクラウド監視用の 1 つのネットワーク セキュリティ グループ (SQLNSG)
 - Web 層用の 1 つのネットワーク セキュリティ グループ (WEBNSG)
 


### PR DESCRIPTION
It is an error to translate "Bastin host" as "要塞ホスト".
In Japan, Bastin Host is called a "踏み台サーバー" or "踏み台ホスト".