### PR TITLE
Fix mistranslation

### DIFF
--- a/articles/security/blueprints/fedramp-datawarehouse-overview.md
+++ b/articles/security/blueprints/fedramp-datawarehouse-overview.md
@@ -37,14 +37,14 @@ SQL ロード バランサーは、SQL トラフィックを管理すること�
 
 このデータ ウェアハウスの参照アーキテクチャには、アーキテクチャ内のリソースを管理するための Active Directory (AD) 層も含まれています。 Active Directory サブネットによって、大規模な AD フォレスト構造への容易な導入が可能になり、大規模なフォレストへのアクセスが利用できない場合でも、環境を継続的に運用できます。 すべての仮想マシンは、Active Directory 層に対してドメイン参加済みであり、Active Directory グループ ポリシーを使用して、オペレーティング システム レベルでセキュリティとコンプライアンスの構成が適用されます。
 
-仮想マシンは管理要塞ホストとして機能し、デプロイされたリソースにアクセスするためのセキュリティで保護された接続を管理者に提供します。 データは、この管理要塞ホストを通してステージング領域に読み込まれます。 **Azure では参照アーキテクチャのサブネットに対する管理とデータ インポートのために、VPN または Azure ExpressRoute 接続を構成することを推奨しています。**
+仮想マシンは管理踏み台ホストとして機能し、デプロイされたリソースにアクセスするためのセキュリティで保護された接続を管理者に提供します。 データは、この管理踏み台ホストを通してステージング領域に読み込まれます。 **Azure では参照アーキテクチャのサブネットに対する管理とデータ インポートのために、VPN または Azure ExpressRoute 接続を構成することを推奨しています。**
 
 ![FedRAMP のためのデータ ウェアハウスの参照アーキテクチャの図](images/fedramp-datawarehouse-architecture.png?raw=true "FedRAMP のためのデータ ウェアハウスの参照アーキテクチャの図")
 
 このソリューションでは、次の Azure サービスを使用します。 デプロイ アーキテクチャの詳細については、「[デプロイメント アーキテクチャ](#deployment-architecture)」セクションを参照してください。
 
 Azure Virtual Machines
--   (1) 要塞ホスト
+-   (1) 踏み台ホスト
 -   (2) Active Directory ドメイン コントローラー
 -   (2) SQL Server クラスター ノード
 -   (1) SQL Server 監視
@@ -79,9 +79,9 @@ Azure Monitor ログ
 
 **SQL Server Reporting Services**: [SQL Server Reporting Services](https://docs.microsoft.com/sql/reporting-services/report-data/sql-azure-connection-type-ssrs) によって、Azure SQL Data Warehouse のテーブル、グラフ、マップ、ゲージ、マトリックスなどを含むレポートをすばやく作成できます。
 
-**要塞ホスト**:要塞ホストは、この環境にデプロイされたリソースへのユーザーのアクセスを許可する単一エントリ ポイントです。 要塞ホストは、セーフ リスト上のパブリック IP アドレスからのリモート トラフィックのみを許可することで、デプロイ済みのリソースへのセキュリティで保護された接続を提供します。 リモート デスクトップ (RDP) トラフィックを許可するには、トラフィックのソースがネットワーク セキュリティ グループ (NSG) に定義されている必要があります。
+**踏み台ホスト**:踏み台ホストは、この環境にデプロイされたリソースへのユーザーのアクセスを許可する単一エントリ ポイントです。 踏み台ホストは、セーフ リスト上のパブリック IP アドレスからのリモート トラフィックのみを許可することで、デプロイ済みのリソースへのセキュリティで保護された接続を提供します。 リモート デスクトップ (RDP) トラフィックを許可するには、トラフィックのソースがネットワーク セキュリティ グループ (NSG) に定義されている必要があります。
 
-仮想マシンは、次の構成を使用してドメイン参加済み要塞ホストとして作成されています。
+仮想マシンは、次の構成を使用してドメイン参加済み踏み台ホストとして作成されています。
 -   [マルウェア対策拡張機能](https://docs.microsoft.com/azure/security/azure-security-antimalware)
 -   [Azure Monitor ログ拡張機能](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-extensions-oms)
 -   [Azure Diagnostics 拡張機能](https://docs.microsoft.com/azure/virtual-machines/virtual-machines-windows-extensions-diagnostics-template)
@@ -94,7 +94,7 @@ Azure Monitor ログ
 
 **ネットワーク セキュリティ グループ**:[NSG](https://docs.microsoft.com/azure/virtual-network/virtual-networks-nsg) には、VNet 内のトラフィックを許可または拒否するアクセス制御リスト (ACL) が含まれます。 NSG を使用して、サブネットまたは個々の VM レベルでトラフィックを保護できます。 次の NSG が存在します。
   - データ層 (SQL Server クラスター、SQL Server 監視、および SQL Load Balancer) 用の NSG
-  - 管理要塞ホスト用の NSG
+  - 管理踏み台ホスト用の NSG
   - Active Directory 用の NSG
   - SQL Server Reporting Services 用の NSG
 


### PR DESCRIPTION
It is an error to translate "Bastin host" as "要塞ホスト".
In Japan, Bastin Host is called a "踏み台サーバー" or "踏み台ホスト".