### PR TITLE
Fix mistranslation

### DIFF
--- a/articles/security/blueprints/fedramp-iaaswa-overview.md
+++ b/articles/security/blueprints/fedramp-iaaswa-overview.md
@@ -40,14 +40,14 @@ ms.locfileid: "60586136"
 デプロイ手順については、[ここ](https://aka.ms/fedrampblueprintrepo)をクリックしてください。
 
 ## <a name="architecture-diagram-and-components"></a>アーキテクチャ ダイアグラムとコンポーネント
-このソリューションは、バックエンドに SQL Server を使用する IaaS Web アプリケーション向けのリファレンス アーキテクチャをデプロイします。 アーキテクチャには、Web 層、データ層、Active Directory インフラストラクチャ、Application Gateway、および Azure Load Balancer が含まれています。 Web 層とデータ層にデプロイされる仮想マシンは可用性セット内に構成され、SQL Server インスタンスは高可用性のために AlwaysOn 可用性グループ内に構成されます。 仮想マシンはドメインに参加し、Active Directory グループ ポリシーを使用して、オペレーティング システム レベルでセキュリティとコンプライアンスの構成が適用されます。 要塞ホストは、デプロイされたリソースにアクセスするためのセキュリティで保護された接続を管理者に提供します。 **Azure では参照アーキテクチャのサブネットに対する管理とデータ インポートのために、VPN または Azure ExpressRoute 接続を構成することを推奨しています。**
+このソリューションは、バックエンドに SQL Server を使用する IaaS Web アプリケーション向けのリファレンス アーキテクチャをデプロイします。 アーキテクチャには、Web 層、データ層、Active Directory インフラストラクチャ、Application Gateway、および Azure Load Balancer が含まれています。 Web 層とデータ層にデプロイされる仮想マシンは可用性セット内に構成され、SQL Server インスタンスは高可用性のために AlwaysOn 可用性グループ内に構成されます。 仮想マシンはドメインに参加し、Active Directory グループ ポリシーを使用して、オペレーティング システム レベルでセキュリティとコンプライアンスの構成が適用されます。 踏み台ホストは、デプロイされたリソースにアクセスするためのセキュリティで保護された接続を管理者に提供します。 **Azure では参照アーキテクチャのサブネットに対する管理とデータ インポートのために、VPN または Azure ExpressRoute 接続を構成することを推奨しています。**
 
 ![FedRAMP のための IaaS Web アプリケーションの参照アーキテクチャ図](images/fedramp-iaaswa-architecture.png?raw=true "FedRAMP のための IaaS Web アプリケーションの参照アーキテクチャ図")
 
 このソリューションでは、次の Azure サービスを使用します。 デプロイ アーキテクチャについて詳しくは、「[デプロイ アーキテクチャ](#deployment-architecture)」セクションをご覧ください。
 
 - Azure Virtual Machines
-    - (1) 要塞ホスト (Microsoft Windows Server 2016 Datacenter)
+    - (1) 踏み台ホスト (Microsoft Windows Server 2016 Datacenter)
     - (2) Active Directory ドメイン コントローラー (Windows Server 2016 Datacenter)
     - (2) SQL Server クラスター ノード (Windows Server 2016 上の SQL Server 2017)
     - (2) Web/IIS (Windows Server 2016 Datacenter)
@@ -78,7 +78,7 @@ ms.locfileid: "60586136"
 
 以下のセクションでは、開発と実装の要素について詳しく説明します。
 
-**要塞ホスト**:要塞ホストは、デプロイされたリソースにアクセスするためのセキュリティで保護された接続を管理者に提供する、単一のエントリ ポイントです。 要塞ホストの NSG は、TCP ポート 3389 のみで RDP 接続を許可します。 お客様は、組織のシステム セキュリティ強化要件を満たすために要塞ホストをさらに詳細に構成できます。
+**踏み台ホスト**:踏み台ホストは、デプロイされたリソースにアクセスするためのセキュリティで保護された接続を管理者に提供する、単一のエントリ ポイントです。 踏み台ホストの NSG は、TCP ポート 3389 のみで RDP 接続を許可します。 お客様は、組織のシステム セキュリティ強化要件を満たすために踏み台ホストをさらに詳細に構成できます。
 
 ### <a name="virtual-network"></a>仮想ネットワーク
 このアーキテクチャは、10.200.0.0/16 のアドレス空間 を使用してプライベート仮想ネットワークを定義します。
@@ -89,7 +89,7 @@ ms.locfileid: "60586136"
 
 各サブネットには、専用のネットワーク セキュリティ グループ (NSG) があります。
 - Application Gateway 用の 1 つの NSG (LBNSG)
-- 要塞ホスト (MGTNSG) 用の 1 つの NSG
+- 踏み台ホスト (MGTNSG) 用の 1 つの NSG
 - プライマリおよびバックアップ ドメイン コントローラー用の 1 つの NSG (ADNSG)
 - SQL Server (SQLNSG) 用の 1 つの NSG
 - Web 層用の 1 つの NSG (WEBNSG)


### PR DESCRIPTION
It is an error to translate "Bastin host" as "要塞ホスト".
In Japan, Bastin Host is called a "踏み台サーバー" or "踏み台ホスト".