### PR TITLE
Fix mistranslation

### DIFF
--- a/articles/application-gateway/overview.md
+++ b/articles/application-gateway/overview.md
@@ -97,7 +97,7 @@ WebSocket および HTTP/2 プロトコルによって、長時間実行され�
 
 詳細については、[WebSocket のサポート](https://docs.microsoft.com/azure/application-gateway/application-gateway-websocket)と [HTTP/2 のサポート](https://docs.microsoft.com/azure/application-gateway/configuration-overview#http2-support)に関するページを参照してください。
 
-## <a name="azure-kubernetes-service-aks-ingress-controller-preview"></a>Azure Kubernetes Service (AKS) のイングレス コントローラーの概要 
+## <a name="azure-kubernetes-service-aks-ingress-controller-preview"></a>Azure Kubernetes Service (AKS) のイングレス コントローラー (プレビュー)
 
 Application Gateway イングレス コントローラーは、AKS クラスター内のポッドとして実行され、Application Gateway が AKS クラスターに対する入り口として機能できるようにします。 これは、Application Gateway v2 でのみサポートされます。
 


### PR DESCRIPTION
The en-us version text is "Azure Kubernetes Service (AKS) Ingress controller".
However, it is mistranslation in ja-jp version text.
So, I fix it.