### PR TITLE
Suggest to fix 'Name'

### DIFF
--- a/articles/storage/common/storage-powershell-independent-clouds.md
+++ b/articles/storage/common/storage-powershell-independent-clouds.md
@@ -81,7 +81,7 @@ Get-AzEnvironment | select Name, StorageEndpointSuffix
 
 このコマンドは、次の結果を返します。
 
-| EnableAdfsAuthentication| StorageEndpointSuffix|
+| Name| StorageEndpointSuffix|
 |----|----|
 | AzureChinaCloud | core.chinacloudapi.cn|
 | AzureCloud | core.windows.net |
@@ -98,7 +98,7 @@ Get-AzEnvironment -Name AzureGermanCloud
 
 |プロパティ名|値|
 |----|----|
-| EnableAdfsAuthentication | AzureGermanCloud |
+| Name | AzureGermanCloud |
 | EnableAdfsAuthentication | False |
 | ActiveDirectoryServiceEndpointResourceI | http://management.core.cloudapi.de/ |
 | GalleryURL | https://gallery.cloudapi.de/ |


### PR DESCRIPTION
`Name` seems to be replaced into `EnableAdfsAuthentication` by accident in many articles.
This article has the real `EnableAdfsAuthentication` .