### PR TITLE
誤訳の修正

### DIFF
--- a/articles/media-services/previous/media-services-portal-vod-get-started.md
+++ b/articles/media-services/previous/media-services-portal-vod-get-started.md
@@ -61,7 +61,7 @@ ms.locfileid: "69015054"
 Media Services を使用してビデオをストリーミングするには、ソース ビデオをアップロードし、複数のビットレートにエンコードして発行します。 このセクションで最初の手順を説明します。 
 
 1. [Azure Portal](https://portal.azure.com/) で Azure Media Services アカウントを選択します。
-2. **[設定]**  >  **[資産]** を参照してください。 次に、 **[アップロード]** ボタンを選択します。
+2. **[設定]**  >  **[アセット]** を参照してください。 次に、 **[アップロード]** ボタンを選択します。
    
     ![ファイルをアップロードする](./media/media-services-portal-vod-get-started/media-services-upload.png)
    
@@ -80,13 +80,13 @@ Media Services を使用してビデオをストリーミングするには、�
 ## <a name="encode-assets"></a>Encode assets
 ダイナミック パッケージを利用するには、ソース ファイルを一連のマルチビットレート MP4 ファイルにエンコードする必要があります。 このセクションでは、エンコードの手順が示されています。
 
-### <a name="encode-assets-in-the-portal"></a>ポータルでの資産のエンコード
+### <a name="encode-assets-in-the-portal"></a>ポータルでのアセットのエンコード
 Azure Portal で Media Encoder Standard を使用してコンテンツをエンコードするには、次の手順に従います。
 
 1. [Azure Portal](https://portal.azure.com/) で Azure Media Services アカウントを選択します。
-2. **[設定]**  >  **[資産]** を参照してください。 エンコードする資産を選択します。
+2. **[設定]**  >  **[アセット]** を参照してください。 エンコードするアセットを選択します。
 3. **[エンコード]** を選択します。
-4. **[資産のエンコード]** ウィンドウで、**Media Encoder Standard** プロセッサとプリセットを選択します。 プリセットについては、[ビットレート ラダーの自動生成](media-services-autogen-bitrate-ladder-with-mes.md)に関するページと [Media Encoder Standard 用のタスク プリセット](media-services-mes-presets-overview.md)に関するページを参照してください。 入力ビデオに最適なプリセットを選択することが重要です。 たとえば、入力ビデオの解像度が 1920 &#215; 1080 ピクセルであるとわかっている場合は、**H264 Multiple Bitrate 1080p** のプリセットを使用します。 低解像度 (640 &#215; 360) のビデオの場合は、**H264 Multiple Bitrate 1080p** プリセットを使用しないでください。
+4. **[アセットのエンコード]** ウィンドウで、**Media Encoder Standard** プロセッサとプリセットを選択します。 プリセットについては、[ビットレート ラダーの自動生成](media-services-autogen-bitrate-ladder-with-mes.md)に関するページと [Media Encoder Standard 用のタスク プリセット](media-services-mes-presets-overview.md)に関するページを参照してください。 入力ビデオに最適なプリセットを選択することが重要です。 たとえば、入力ビデオの解像度が 1920 &#215; 1080 ピクセルであるとわかっている場合は、**H264 Multiple Bitrate 1080p** のプリセットを使用します。 低解像度 (640 &#215; 360) のビデオの場合は、**H264 Multiple Bitrate 1080p** プリセットを使用しないでください。
    
    リソースを管理しやすくするために、出力アセットの名前とジョブの名前を編集することができます。
    
@@ -99,16 +99,16 @@ Azure Portal で Media Encoder Standard を使用してコンテンツをエン�
 ![[ジョブ]](./media/media-services-portal-vod-get-started/media-services-jobs.png)
 
 ## <a name="publish-content"></a>コンテンツを発行する
-コンテンツのストリーミングまたはダウンロードに使用できる URL をユーザーに提供するには、まず、ロケーターを作成してアセットを発行する必要があります。 資産内のファイルには、ロケーターを通じてアクセスできます。 Azure Media Services では、次の 2 種類のロケーターがサポートされています。 
+コンテンツのストリーミングまたはダウンロードに使用できる URL をユーザーに提供するには、まず、ロケーターを作成してアセットを発行する必要があります。 アセット内のファイルには、ロケーターを通じてアクセスできます。 Azure Media Services では、次の 2 種類のロケーターがサポートされています。 
 
-* **ストリーミング (OnDemandOrigin) ロケーター**。 ストリーミング ロケーターは、アダプティブ ストリーミングに使用されます。 アダプティブ ストリーミングの例として、HLS、Smooth Streaming、MPEG-DASH などが挙げられます。 ストリーミング ロケーターを作成するには、資産に .ism ファイルが含まれている必要があります。 
+* **ストリーミング (OnDemandOrigin) ロケーター**。 ストリーミング ロケーターは、アダプティブ ストリーミングに使用されます。 アダプティブ ストリーミングの例として、HLS、Smooth Streaming、MPEG-DASH などが挙げられます。 ストリーミング ロケーターを作成するには、アセットに .ism ファイルが含まれている必要があります。 
 * **プログレッシブ (Shared Access Signature) ロケーター**。 プログレッシブ ロケーターは、プログレッシブ ダウンロードを通じてビデオを配信する場合に使用されます。
 
 HLS ストリーミング URL を作成するには、次のように、 *(format=m3u8-aapl)* を URL に追加します。
 
     {streaming endpoint name-media services account name}.streaming.mediaservices.windows.net/{locator ID}/{file name}.ism/Manifest(format=m3u8-aapl)
 
-Smooth Streaming 資産を再生するためのストリーミング URL を作成するには、次の URL 形式を使用します。
+Smooth Streaming アセットを再生するためのストリーミング URL を作成するには、次の URL 形式を使用します。
 
     {streaming endpoint name-media services account name}.streaming.mediaservices.windows.net/{locator ID}/{file name}.ism/Manifest
 
@@ -132,7 +132,7 @@ Shared Access Signature URL の形式は、次のとおりです。
 
 ### <a name="to-use-the-portal-to-publish-an-asset"></a>ポータルを使用してアセットを発行するには
 1. [Azure Portal](https://portal.azure.com/) で Azure Media Services アカウントを選択します。
-2. **[設定]**  >  **[資産]** を参照してください。 発行する資産を選択します。
+2. **[設定]**  >  **[アセット]** を参照してください。 発行するアセットを選択します。
 3. **[発行]** を選択します。
 4. ロケーターの種類を選択します。
 5. **[追加]** を選択します。


### PR DESCRIPTION
"Asset"の訳が「資産」になっているが、Azure Portalでの訳は「アセット」となっている。
このため、「アセット」に文言を統一した。