### PR TITLE
過剰な翻訳

### DIFF
--- a/articles/azure-monitor/platform/metrics-supported.md
+++ b/articles/azure-monitor/platform/metrics-supported.md
@@ -330,11 +330,11 @@ Azure Monitor では、複数の方法を使用してメトリックを操作で
 |---|---|---|---|---|---|
 |Percentage CPU|CPU の割合|Percent|平均|仮想マシンで現在使用されている、割り当てられたコンピューティング ユニットの割合。|ディメンションなし|
 |Network In|ネットワーク受信|Bytes|合計|すべてのネットワーク インターフェイスで仮想マシンが受信したバイト数 (受信トラフィック)。|ディメンションなし|
-|ネットワーク送信|ネットワーク送信|Bytes|合計|すべてのネットワーク インターフェイスで仮想マシンが送信したバイト数 (送信トラフィック)。|ディメンションなし|
+|Network Out|ネットワーク送信|Bytes|合計|すべてのネットワーク インターフェイスで仮想マシンが送信したバイト数 (送信トラフィック)。|ディメンションなし|
 |Disk Read Bytes/Sec|ディスクの読み取り|BytesPerSecond|平均|監視期間中にディスクから読み取られた平均バイト数。|ディメンションなし|
 |Disk Write Bytes/Sec|ディスクの書き込み|BytesPerSecond|平均|監視期間中にディスクに書き込まれた平均バイト数。|ディメンションなし|
 |Disk Read Operations/Sec|ディスク読み取り操作数/秒|CountPerSecond|平均|ディスク読み取り IOPS。|ディメンションなし|
-|ディスク書き込み操作数/秒|ディスク書き込み操作数/秒|CountPerSecond|平均|ディスク書き込み IOPS。|ディメンションなし|
+|Disk Write Operations/Sec|ディスク書き込み操作数/秒|CountPerSecond|平均|ディスク書き込み IOPS。|ディメンションなし|
 
 ## <a name="microsoftclassiccomputedomainnamesslotsroles"></a>Microsoft.ClassicCompute/domainNames/slots/roles
 
@@ -342,11 +342,11 @@ Azure Monitor では、複数の方法を使用してメトリックを操作で
 |---|---|---|---|---|---|
 |Percentage CPU|CPU の割合|Percent|平均|仮想マシンで現在使用されている、割り当てられたコンピューティング ユニットの割合。|RoleInstanceId|
 |Network In|ネットワーク受信|Bytes|合計|すべてのネットワーク インターフェイスで仮想マシンが受信したバイト数 (受信トラフィック)。|RoleInstanceId|
-|ネットワーク送信|ネットワーク送信|Bytes|合計|すべてのネットワーク インターフェイスで仮想マシンが送信したバイト数 (送信トラフィック)。|RoleInstanceId|
+|Network Out|ネットワーク送信|Bytes|合計|すべてのネットワーク インターフェイスで仮想マシンが送信したバイト数 (送信トラフィック)。|RoleInstanceId|
 |Disk Read Bytes/Sec|ディスクの読み取り|BytesPerSecond|平均|監視期間中にディスクから読み取られた平均バイト数。|RoleInstanceId|
 |Disk Write Bytes/Sec|ディスクの書き込み|BytesPerSecond|平均|監視期間中にディスクに書き込まれた平均バイト数。|RoleInstanceId|
 |Disk Read Operations/Sec|ディスク読み取り操作数/秒|CountPerSecond|平均|ディスク読み取り IOPS。|RoleInstanceId|
-|ディスク書き込み操作数/秒|ディスク書き込み操作数/秒|CountPerSecond|平均|ディスク書き込み IOPS。|RoleInstanceId|
+|Disk Write Operations/Sec|ディスク書き込み操作数/秒|CountPerSecond|平均|ディスク書き込み IOPS。|RoleInstanceId|
 
 ## <a name="microsoftcognitiveservicesaccounts"></a>Microsoft.CognitiveServices/accounts
 
@@ -373,11 +373,11 @@ Azure Monitor では、複数の方法を使用してメトリックを操作で
 |---|---|---|---|---|---|
 |Percentage CPU|CPU の割合|Percent|平均|仮想マシンで現在使用されている、割り当てられたコンピューティング ユニットの割合|ディメンションなし|
 |Network In|課金対象の受信ネットワーク|Bytes|合計|すべてのネットワーク インターフェイスで仮想マシンが受信した課金対象のバイト数 (受信トラフィック)|ディメンションなし|
-|ネットワーク送信|課金対象の送信ネットワーク|Bytes|合計|すべてのネットワーク インターフェイスで仮想マシンが送信した課金対象のバイト数 (送信トラフィック)|ディメンションなし|
+|Network Out|課金対象の送信ネットワーク|Bytes|合計|すべてのネットワーク インターフェイスで仮想マシンが送信した課金対象のバイト数 (送信トラフィック)|ディメンションなし|
 |Disk Read Bytes|ディスク読み取りバイト数|Bytes|合計|監視期間中にディスクから読み取られたバイト数|ディメンションなし|
 |Disk Write Bytes|ディスク書き込みバイト数|Bytes|合計|監視期間中にディスクに書き込まれたバイト数|ディメンションなし|
 |Disk Read Operations/Sec|ディスク読み取り操作数/秒|CountPerSecond|平均|ディスク読み取り IOPS|ディメンションなし|
-|ディスク書き込み操作数/秒|ディスク書き込み操作数/秒|CountPerSecond|平均|ディスク書き込み IOPS|ディメンションなし|
+|Disk Write Operations/Sec|ディスク書き込み操作数/秒|CountPerSecond|平均|ディスク書き込み IOPS|ディメンションなし|
 |CPU Credits Remaining|未使用の CPU クレジット|Count|平均|バーストに使用できるクレジットの合計|ディメンションなし|
 |CPU Credits Consumed|使用済みの CPU クレジット|Count|平均|仮想マシンによって消費されたクレジットの合計数|ディメンションなし|
 |Per Disk Read Bytes/sec|データ ディスク読み取りバイト数/秒 (非推奨)|CountPerSecond|平均|監視期間中に 1 つのディスクから読み取られたバイト数/秒|SlotId|
@@ -417,7 +417,7 @@ Azure Monitor では、複数の方法を使用してメトリックを操作で
 |---|---|---|---|---|---|
 |Percentage CPU|CPU の割合|Percent|平均|仮想マシンで現在使用されている、割り当てられたコンピューティング ユニットの割合|VMName|
 |Network In|課金対象の受信ネットワーク|Bytes|合計|すべてのネットワーク インターフェイスで仮想マシンが受信した課金対象のバイト数 (受信トラフィック)|VMName|
-|ネットワーク送信|課金対象の送信ネットワーク|Bytes|合計|すべてのネットワーク インターフェイスで仮想マシンが送信した課金対象のバイト数 (送信トラフィック)|VMName|
+|Network Out|課金対象の送信ネットワーク|Bytes|合計|すべてのネットワーク インターフェイスで仮想マシンが送信した課金対象のバイト数 (送信トラフィック)|VMName|
 |Disk Read Bytes|ディスク読み取りバイト数|Bytes|合計|監視期間中にディスクから読み取られたバイト数|VMName|
 |Disk Write Bytes|ディスク書き込みバイト数|Bytes|合計|監視期間中にディスクに書き込まれたバイト数|VMName|
 |Disk Read Operations/Sec|ディスク読み取り操作数/秒|CountPerSecond|平均|ディスク読み取り IOPS|VMName|
@@ -1642,7 +1642,7 @@ Azure Monitor では、複数の方法を使用してメトリックを操作で
 |NetworkInBytesPerSecond|受信ネットワークのバイト数/秒|BytesPerSecond|平均|受信トラフィックの平均ネットワーク スループット。|ディメンションなし|
 |NetworkOutBytesPerSecond|送信ネットワークのバイト数/秒|BytesPerSecond|平均|送信トラフィックの平均ネットワーク スループット。|ディメンションなし|
 |Network In|ネットワーク受信|Bytes|合計|受信トラフィックの合計ネットワーク スループット。|ディメンションなし|
-|ネットワーク送信|ネットワーク送信|Bytes|合計|送信トラフィックの合計ネットワーク スループット。|ディメンションなし|
+|Network Out|ネットワーク送信|Bytes|合計|送信トラフィックの合計ネットワーク スループット。|ディメンションなし|
 |MemoryUsed|メモリ使用量|Bytes|平均|VM によって使用されているマシンのメモリの容量。|ディメンションなし|
 |MemoryGranted|許可されているメモリ量|Bytes|平均|ホストによって VM に許可されたメモリの容量。 VMkernel がメモリを必要とした場合、一度アクセスされ、許可されたメモリがスワップ アウトされるか、バルーニングされるまで、メモリはホストに与えられません。|ディメンションなし|
 |MemoryActive|アクティブなメモリ|Bytes|平均|過去の小さな時間枠で VM によって使用されたメモリの容量。 これは、VM が現在必要としているメモリの容量の「真」の数値です。 ゲストのパフォーマンスに影響を与えずに、追加の未使用メモリをスワップ アウトするか、バルーニングできます。|ディメンションなし|


### PR DESCRIPTION
メトリックは PowerShell など処理するために必要な値のため、翻訳不要。