### PR TITLE
Fix excessive translation

### DIFF
--- a/articles/azure-app-configuration/quickstart-dotnet-core-app.md
+++ b/articles/azure-app-configuration/quickstart-dotnet-core-app.md
@@ -28,7 +28,7 @@ ms.locfileid: "68326563"
 ## <a name="prerequisites"></a>前提条件
 
 - Azure サブスクリプション - [無料アカウントを作成する](https://azure.microsoft.com/free/)
-- [.NET コア SDK](https://dotnet.microsoft.com/download)
+- [.NET Core SDK](https://dotnet.microsoft.com/download)
 
 ## <a name="create-an-app-configuration-store"></a>アプリ構成ストアを作成する
 


### PR DESCRIPTION
- `.NET コア SDK`  should be `.NET Core SDK`