### PR TITLE
Improve translations

### DIFF
--- a/articles/cognitive-services/Speech-Service/how-to-use-conversation-transcription.md
+++ b/articles/cognitive-services/Speech-Service/how-to-use-conversation-transcription.md
@@ -108,13 +108,13 @@ class Program
 
 サンプル コードの特徴を次に示します。
 
-- `Guid.NewGuid()` を使用して作成された会議の識別子を使用する `SpeechConfig` オブジェクトから `Conversation` オブジェクトを作成する
+- `Guid.NewGuid()` を使用して作成された会議の識別子を使用して `SpeechConfig` オブジェクトから `Conversation` オブジェクトを作成する
 - `ConversationTranscriber` オブジェクトを作成し、`JoinConversationAsync()` を使用して会話に参加して文字起こしを開始する
 - 関心のあるイベントを登録する
 - Conversation オブジェクトを使用して、参加者を会話に追加または削除する
 - オーディオのストリーミング
 
-文字起こしと話者の識別子は、登録されたイベントで再び使用することができます。
+文字起こしと話者の識別子は、登録されたイベントで返されます。
 
 ```csharp
 using Microsoft.CognitiveServices.Speech;


### PR DESCRIPTION
- 'using a meeting identifier ...' seems to explain 'Creating'. 
- 'come back' seems to mean that `Text` and `UserId` are given via args in `Transcribed` event.