### PR TITLE
Improve translation

### DIFF
--- a/articles/role-based-access-control/resource-provider-operations.md
+++ b/articles/role-based-access-control/resource-provider-operations.md
@@ -3906,8 +3906,8 @@ ms.locfileid: "74895559"
 > | Action | Microsoft.Network/bastionHosts/createbsl/action | 要塞内の VM の共有可能な URL を作成し、URL を返します |
 > | Action | Microsoft.Network/bastionHosts/delete | 踏み台ホストを削除します |
 > | Action | Microsoft.Network/bastionHosts/deletebsl/action | 要塞内の指定された VM の共有可能な URL を削除します |
-> | Action | Microsoft.Network/bastionHosts/disconnectactivesessions/action | 要塞ホストで特定のアクティブなセッションを切断します |
-> | Action | Microsoft.Network/bastionHosts/getactivesessions/action | 要塞ホストでアクティブなセッションを取得します |
+> | Action | Microsoft.Network/bastionHosts/disconnectactivesessions/action | 踏み台ホストで特定のアクティブなセッションを切断します |
+> | Action | Microsoft.Network/bastionHosts/getactivesessions/action | 踏み台ホストでアクティブなセッションを取得します |
 > | Action | Microsoft.Network/bastionHosts/getbsl/action | URL が作成された場合に、要塞サブネット内の指定された VM の共有可能な URL を返します |
 > | Action | Microsoft.Network/bastionHosts/read | 踏み台ホストを取得します |
 > | Action | Microsoft.Network/bastionHosts/write | 踏み台ホストを作成または更新します |


### PR DESCRIPTION
It is an error to translate "Bastin host" as "要塞ホスト".
In Japan, Bastin Host is called a "踏み台サーバー" or "踏み台ホスト".

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
