### PR TITLE
Refer to correct NuGet package in direct method sample

### DIFF
--- a/articles/iot-hub/iot-hub-csharp-csharp-schedule-jobs.md
+++ b/articles/iot-hub/iot-hub-csharp-csharp-schedule-jobs.md
@@ -174,7 +174,7 @@ Azure IoT Hub を使用して、数百万のデバイスを更新するジョブ
 
 1. ソリューション エクスプローラーで **[ScheduleJob]** プロジェクトを右クリックし、 **[NuGet パッケージの管理]** を選択します。
 
-1. **[NuGet パッケージ マネージャー]** で **[参照]** を選択し、**Microsoft.Azure.Devices.Client** を検索して選択してから、 **[インストール]** を選択します。
+1. **[NuGet パッケージ マネージャー]** で **[参照]** を選択し、**Microsoft.Azure.Devices** を検索して選択してから、 **[インストール]** を選択します。
 
    この手順により、パッケージのダウンロードとインストールが実行され、[Azure IoT service SDK](https://www.nuget.org/packages/Microsoft.Azure.Devices/) NuGet パッケージへの参照とその依存関係が追加されます。
 


### PR DESCRIPTION
fragment "schedule-jobs-for-calling-a-direct-method-and-sending-device-twin-updates"

Step 4 originally referenced "Microsoft.Azure.Devices.Client" but changed that to "Microsoft.Azure.Devices" since the latter is the required package for the sample to work

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
