### PR TITLE
Update sql-database-xevent-db-diff-from-svr.md

### DIFF
--- a/articles/sql-database/sql-database-xevent-db-diff-from-svr.md
+++ b/articles/sql-database/sql-database-xevent-db-diff-from-svr.md
@@ -74,7 +74,7 @@ Azure SQL Database と Microsoft SQL Server の拡張イベントについては
 - **ON DATABASE** 句も [ALTER EVENT SESSION](https://msdn.microsoft.com/library/bb630368.aspx) および [DROP EVENT SESSION Transact-SQL](https://msdn.microsoft.com/library/bb630257.aspx) コマンドに適用されます。
 
 
-- **CREATE EVENT SESSION** または **ALTER EVENT SESSION** ステートメントで **STARTUP_STATE = ON** のイベント セッション オプションを含ませるベスト プラクティス。
+- **CREATE EVENT SESSION** または **ALTER EVENT SESSION** ステートメントで **STARTUP_STATE = ON** のイベント セッション オプションを含ませるのがベスト プラクティスです。
     - **= ON** 値は、フェールオーバーに伴う論理データベース再構成の後の自動再起動をサポートします。
 
 ## <a name="new-catalog-views"></a>新しいカタログ ビュー


### PR DESCRIPTION
誤訳
A best practice is to include the event session option of STARTUP_STATE = ON in your CREATE EVENT SESSION or ALTER EVENT SESSION statements.
https://docs.microsoft.com/en-us/azure/sql-database/sql-database-xevent-db-diff-from-svr

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
