### PR TITLE
Update network-watcher-windows.md

### DIFF
--- a/articles/virtual-machines/extensions/network-watcher-windows.md
+++ b/articles/virtual-machines/extensions/network-watcher-windows.md
@@ -34,7 +34,7 @@ ms.locfileid: "81261671"
 
 ### <a name="operating-system"></a>オペレーティング システム
 
-Windows 用の Network Watcher Agent 拡張機能は、Windows Server 2008 R2、2012、2012 R2、2016 の各リリースで実行できます。 現時点では、Nano Server はサポートされていません。
+Windows 用の Network Watcher Agent 拡張機能は、Windows Server 2008 R2、2012、2012 R2、2016、2019 の各リリースで実行できます。 現時点では、Nano Server はサポートされていません。
 
 ### <a name="internet-connectivity"></a>インターネット接続
 


### PR DESCRIPTION
(English Ver)
Operating system
The Network Watcher Agent extension for Windows can be run against Windows Server 2008 R2, 2012, 2012 R2, 2016 and 2019 releases. Nano Server is not supported at this time.