### PR TITLE
adding missing '-' in a command

### DIFF
--- a/articles/container-registry/container-registry-authentication.md
+++ b/articles/container-registry/container-registry-authentication.md
@@ -53,7 +53,7 @@ Azure ID で `az acr login` を使用すると、[Azure ロールベースのア
 このシナリオでは、最初に `--expose-token` パラメーターを指定して `az acr login` を実行します。 このオプションは、Docker CLI を使用してログインするのではなく、アクセス トークンを公開します。
 
 ```azurecli
-az acr login -name <acrName> --expose-token
+az acr login --name <acrName> --expose-token
 ```
 
 出力には、次のようにアクセス トークン (ここでは省略されています) が表示されます。


### PR DESCRIPTION
In one command example  '-' was missing, so I added it. /// コマンド例の一つで'-'が抜けていたので追加しました。

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
