### PR TITLE
missing limitation in AppServiceFileAuditLogs

### DIFF
--- a/articles/app-service/troubleshoot-diagnostic-logs.md
+++ b/articles/app-service/troubleshoot-diagnostic-logs.md
@@ -191,7 +191,7 @@ Windows アプリの場合、ZIP ファイルには、App Service ファイル �
 | AppServiceHTTPLogs | はい | はい | Web サーバー ログ |
 | AppServiceEnvironmentPlatformLogs | はい | はい | App Service Environment: スケーリング、構成変更、および状態ログ|
 | AppServiceAuditLogs | はい | はい | FTP および Kudu 経由のログイン アクティビティ |
-| AppServiceFileAuditLogs | はい | TBD | FTP および Kudu 経由のファイル変更 |
+| AppServiceFileAuditLogs | はい | TBD | FTP および Kudu 経由のファイル変更。Premium 以上の App Service プラン にて利用可能 |
 | AppServiceAppLogs | TBA | Java SE および Tomcat | アプリケーション ログ |
 | AppServiceIPSecAuditLogs  | はい | はい | IP ルールからの要求 |
 | AppServicePlatformLogs  | TBA | はい | コンテナー ログ |


### PR DESCRIPTION
In Japanese troubleshoot-diagnostic-logs.md, there is missing limitation in AppServiceFileAuditLogs.
In the following English version, there is the limitation of  'only available for Premium tier and above' at the end of its explanation cell in AppServiceFileAuditLogs record.

https://docs.microsoft.com/en-us/azure/app-service/troubleshoot-diagnostic-logs#supported-log-types

But in Japanese version, the above limitation is not documented. This PR try to add the limitation in Japanese document not to lead misunderstanding of our customers.

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
