### PR TITLE
Netflix の二段階認証は利用できません。

### DIFF
--- a/articles/active-directory/user-help/user-help-auth-app-add-non-ms-account.md
+++ b/articles/active-directory/user-help/user-help-auth-app-add-non-ms-account.md
@@ -36,7 +36,7 @@ ms.locfileid: "87015972"
     >[!Note]
     >初めて Microsoft Authenticator アプリを設定する場合は、アプリによるカメラへのアクセスを許可するか (iOS)、またはアプリによる画像の撮影とビデオの録画を許可するか (Android) を確認するメッセージが表示されることがあります。 認証アプリがカメラにアクセスして、次の手順で QR コードを撮影できるようにするには、 **[許可]** を選択する必要があります。 カメラを許可しない場合でも、認証アプリを設定できますが、手動でコード情報を追加する必要があります。 コードを手動で追加する方法の詳細については、「[アプリにアカウントを手動で追加する](user-help-auth-app-add-account-manual.md)」を参照してください。
 
-ここでは、Facebook、Google、GitHub、および Amazon のアカウントに関するプロセスについて説明しますが、このプロセスは、Instagram、Netflix、または Adobe などの他のアプリの場合も同じです。
+ここでは、Facebook、Google、GitHub、および Amazon のアカウントに関するプロセスについて説明しますが、このプロセスは、Instagram、または Adobe などの他のアプリの場合も同じです。
 
 ## <a name="add-your-google-account"></a>Google アカウントを追加する
 


### PR DESCRIPTION
Netflix ではメールアドレスと支払い方法の変更時に登録メールアドレスに認証コードを送信するだけです。

cf. https://github.com/MicrosoftDocs/azure-docs/pull/64506
