### PR TITLE
Fix CONTRIBUTING.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ ms.locfileid: "67338238"
 
 ## <a name="getting-started"></a>Getting Started (概要)
 
-オープン ソースの共同作成とは、ドキュメントを更新する行為のみを指すものではありません。問題を見つけたときに Microsoft に連絡することも含まれます。 詳細については、Microsoft の[共同作成ガイダンス](CONTRIBUTING.md)を参照してください。
+オープン ソースの共同作成とは、ドキュメントを更新する行為のみを指すものではありません。問題を見つけたときに Microsoft に連絡することも含まれます。 詳細については、Microsoft の[共同作成ガイダンス](https://github.com/MicrosoftDocs/azure-docs/blob/master/CONTRIBUTING.md)を参照してください。
 
 ### <a name="prerequisites"></a>前提条件
 


### PR DESCRIPTION
## Why

I'm not sure how to contribute to this repository because CONTRIBUTING.md is a dead-link.
ref https://github.com/MicrosoftDocs/azure-docs.ja-jp/blob/4be058f63a586909eac17f3181dc05ba26ace0fb/.github/CONTRIBUTING.md

## What

Fix link. I suggest [this link](https://github.com/MicrosoftDocs/azure-docs/blob/master/CONTRIBUTING.md) because this repository translates from [MicrosoftDocs/azure-docs](https://github.com/MicrosoftDocs/azure-docs).

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
