### PR TITLE
Fix translated in speech-synthesis-markup.md

### DIFF
--- a/articles/cognitive-services/Speech-Service/speech-synthesis-markup.md
+++ b/articles/cognitive-services/Speech-Service/speech-synthesis-markup.md
@@ -403,7 +403,7 @@ speechConfig!.setPropertyTo(
 | なし、または値が指定されていない場合 | 0 ミリ秒        |
 | x-weak                        | 250 ミリ秒      |
 | weak                          | 500 ミリ秒      |
-| 中                        | 750 ミリ秒      |
+| medium                        | 750 ミリ秒      |
 | strong                        | 1000 ミリ秒     |
 | x-strong                      | 1250 ミリ秒     |
 


### PR DESCRIPTION
提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。

## Why

`strength` sets a variable(``, `x-weak`, `weak`, `medium`, `strong`, `x-strong`). Only `medium` is mistakenly translated.
ref https://github.com/MicrosoftDocs/azure-docs.ja-jp/blame/9d06c226ae6b36c95df1db8e37027e872f383f46/articles/cognitive-services/Speech-Service/speech-synthesis-markup.md#L390

`<break strength="string" />`

## What

`中` -> `medium`