### PR TITLE
Fix translate('終了' -> '終端'). Update configure-ssl-bindings.md

### DIFF
--- a/articles/app-service/configure-ssl-bindings.md
+++ b/articles/app-service/configure-ssl-bindings.md
@@ -149,9 +149,9 @@ ms.locfileid: "102039803"
 
 操作が完了すると、アプリは下位の TLS バージョンでの接続をすべて拒否します。
 
-## <a name="handle-tls-termination"></a>TLS 終了の処理
+## <a name="handle-tls-termination"></a>TLS 終端の処理
 
-App Service では、[TLS 終了](https://wikipedia.org/wiki/TLS_termination_proxy)がネットワーク ロード バランサーで発生するため、すべての HTTPS 要求は暗号化されていない HTTP 要求としてアプリに到達します。 ユーザー要求が暗号化されているかどうかをアプリ ロジックが確認する必要がある場合は、`X-Forwarded-Proto` ヘッダーを調べます。
+App Service では、[TLS 終端](https://wikipedia.org/wiki/TLS_termination_proxy)がネットワーク ロード バランサーで発生するため、すべての HTTPS 要求は暗号化されていない HTTP 要求としてアプリに到達します。 ユーザー要求が暗号化されているかどうかをアプリ ロジックが確認する必要がある場合は、`X-Forwarded-Proto` ヘッダーを調べます。
 
 [Linux Node.js 構成](configure-language-nodejs.md#detect-https-session)ガイドなどの言語固有の構成ガイドでは、アプリケーション コード内の HTTPS セッションを検出する方法について説明しています。
 


### PR DESCRIPTION
提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。

## Why

"TLS termination" commonly translated as "TLS 終端".

## What

Fix `s/終了/終端/`