### PR TITLE
Fix translate('終了' -> '終端'). Update operator-best-practices-multi-region.md

### DIFF
--- a/articles/aks/operator-best-practices-multi-region.md
+++ b/articles/aks/operator-best-practices-multi-region.md
@@ -59,7 +59,7 @@ Traffic Manager は DNS 参照を実行して、ユーザーの最も適切な�
 
 ### <a name="application-routing-with-azure-front-door-service"></a>Azure Front Door Service を使用したアプリケーション ルーティング
 
-[Azure Front Door Service](../frontdoor/front-door-overview.md) は、スプリット TCP ベースのエニーキャスト プロトコルを使用して、エンド ユーザーが最も近い Front Door POP (point of presence) にすぐに接続されるようにします。 Azure Front Door Service の追加機能としては、TLS 終了、カスタム ドメイン、Web アプリケーション ファイアウォール、URL の書き換え、セッション アフィニティがあります。 アプリケーション トラフィックのニーズを確認して、どのソリューションが最も適切かを検討してください。
+[Azure Front Door Service](../frontdoor/front-door-overview.md) は、スプリット TCP ベースのエニーキャスト プロトコルを使用して、エンド ユーザーが最も近い Front Door POP (point of presence) にすぐに接続されるようにします。 Azure Front Door Service の追加機能としては、TLS 終端、カスタム ドメイン、Web アプリケーション ファイアウォール、URL の書き換え、セッション アフィニティがあります。 アプリケーション トラフィックのニーズを確認して、どのソリューションが最も適切かを検討してください。
 
 ### <a name="interconnect-regions-with-global-virtual-network-peering"></a>グローバル仮想ネットワーク ピアリングを使用してリージョンを相互接続する
 


### PR DESCRIPTION
提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。

## Why

"TLS termination" commonly translated as "TLS 終端".

## What

Fix `s/終了/終端/`