### PR TITLE
Update translation in App Service Documentation

### DIFF
--- a/articles/app-service/overview-authentication-authorization.md
+++ b/articles/app-service/overview-authentication-authorization.md
@@ -138,7 +138,7 @@ App Service または [Azure Functions](../azure-functions/functions-overview.md
 
 詳しくは、「[ユーザー要求へのアクセス](app-service-authentication-how-to.md#access-user-claims)」をご覧ください。
 
-現時点では、現在のユーザーに Authentication/Authorization 機能を設定することは ASP.NET Core ではサポートされていません。 ただし、このギャップを埋めるのに役立つ[サードパーティのオープン ソースのミドルウェア コンポーネント](https://github.com/MaximRouiller/MaximeRouiller.Azure.AppService.EasyAuth)は存在します。
+.NET Core の場合、[Microsoft.Identity.Web](https://www.nuget.org/packages/Microsoft.Identity.Web/) は、現在のユーザーへの認証/承認機能の設定をサポートします。詳細については、[Microsoft.Identity.Web wiki](https://github.com/AzureAD/microsoft-identity-web/wiki/1.2.0#integration-with-azure-app-services-authentication-of-web-apps-running-with-microsoftidentityweb) で確認するか、[このチュートリアル](https://docs.microsoft.com/en-us/azure/app-service/scenario-secure-app-access-microsoft-graph-as-user?tabs=command-line#install-client-library-packages)で Microsoft Graph にアクセスする Web アプリのデモを参照してください。
 
 #### <a name="token-store"></a>トークン ストア
 


### PR DESCRIPTION
## Why
The Japanese translation is completely different from the English document.

### English
For .NET Core, Microsoft.Identity.Web supports populating the current user with the Authentication/Authorization feature. To learn more, you can read about it on the Microsoft.Identity.Web wiki, or see it demonstrated in this tutorial for a web app accessing Microsoft Graph.

### Japanese (Current)
```
現時点では、現在のユーザーに Authentication/Authorization 機能を設定することは ASP.NET Core ではサポートされていません。 ただし、このギャップを埋めるのに役立つサードパーティのオープン ソースのミドルウェア コンポーネントは存在します。
```

### Japanse (Proposal)
```
.NET Core の場合、[Microsoft.Identity.Web](https://www.nuget.org/packages/Microsoft.Identity.Web/) は、現在のユーザーへの認証/承認機能の設定をサポートします。詳細については、[Microsoft.Identity.Web wiki](https://github.com/AzureAD/microsoft-identity-web/wiki/1.2.0#integration-with-azure-app-services-authentication-of-web-apps-running-with-microsoftidentityweb) で確認するか、[このチュートリアル](https://docs.microsoft.com/en-us/azure/app-service/scenario-secure-app-access-microsoft-graph-as-user?tabs=command-line#install-client-library-packages)で Microsoft Graph にアクセスする Web アプリのデモを参照してください。
```

提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
