### PR TITLE
Fix wrong kanji

### DIFF
--- a/articles/active-directory/roles/TOC.yml
+++ b/articles/active-directory/roles/TOC.yml
@@ -59,7 +59,7 @@
               href: custom-enterprise-app-permissions.md
             - name: アプリへの同意のアクセス許可
               href: custom-consent-permissions.md
-        - name: アプリの管理社ロールを委任する
+        - name: アプリの管理者ロールを委任する
           href: delegate-app-roles.md
     - name: ロールをグループに割り当てる
       items:


### PR DESCRIPTION
TOC の翻訳後の漢字の変換ミスを修正した。

:x: 管理社 (ref: https://en.wiktionary.org/wiki/%E7%A4%BE )
:o: 管理者 (ref: https://en.wiktionary.org/wiki/%E8%80%85 )


提案を送信するための役立つ情報:
1.[ローカライズ スタイル ガイドのクイック スタート](https://docs.microsoft.com/globalization/localization/styleguides) に移動して、Microsoft スタイル ガイドの **最も重要なルール上位 10 個** をご確認ください。
2.[Microsoft ランゲージ ポータル](https://www.microsoft.com/language) に移動して、Microsoft 製品間での **標準化された用語の翻訳** をご確認ください。
