### PR TITLE
The logout URL to be set in Sansan should be a WS-Fed endpoint | Update sansan-tutorial.md

### DIFF
--- a/articles/active-directory/saas-apps/sansan-tutorial.md
+++ b/articles/active-directory/saas-apps/sansan-tutorial.md
@@ -102,6 +102,10 @@ Sansan で Azure AD SSO を構成してテストするには、次の構成要�
 
    ![構成 URL のコピー](common/copy-configuration-urls.png)
 
+   ```Logout URL
+    https://login.microsoftonline.com/common/wsfederation?wa=wsignout1.0
+    ```
+
 ### <a name="create-an-azure-ad-test-user"></a>Azure AD のテスト ユーザーの作成
 
 このセクションでは、Azure portal で Britta Simon というテスト ユーザーを作成します。


### PR DESCRIPTION
## Why

from https://github.com/MicrosoftDocs/azure-docs/issues/75891#issuecomment-870493174 https://github.com/MicrosoftDocs/azure-docs/issues/77649

The Japanese page has not been fixed. It has already been fixed on the en-us page. ref 　https://github.com/MicrosoftDocs/azure-docs/commit/8b40b2f2bf5817f115f302d42acb2a2e388c5a8f

![Tutorial__Azure_Active_Directory_integration_with_Sansan___Microsoft_Docs](https://user-images.githubusercontent.com/2929102/130052656-37e8d511-0b34-497f-8c35-54dfa1c3c87a.png)

## What

Fix it.

before | after
 -- | --
![チュートリアル_Azure_Active_Directory_と_Sansan_の統合___Microsoft_Docs](https://user-images.githubusercontent.com/2929102/130052784-f6065068-c523-4a84-8060-6cd65e1dbee5.png) | ![Tutorial__Azure_Active_Directory_integration_with_Sansan___Microsoft_Docs](https://user-images.githubusercontent.com/2929102/130052656-37e8d511-0b34-497f-8c35-54dfa1c3c87a.png)
