### PR TITLE
fix toc deployment-complete-mode

### DIFF
--- a/articles/azure-resource-manager/templates/toc.yml
+++ b/articles/azure-resource-manager/templates/toc.yml
@@ -301,7 +301,7 @@
       href: deployment-modes.md
     - name: デプロイ履歴の削除
       href: deployment-history-deletions.md
-    - name: デプロイ完了モードの削除
+    - name: デプロイ完全モードの削除
       href: deployment-complete-mode-deletion.md
 - name: 方法
   items:


### PR DESCRIPTION
Fix `デプロイ完了モード` to `デプロイ完全モード`.

The [page title](https://learn.microsoft.com/ja-jp/azure/azure-resource-manager/templates/deployment-complete-mode-deletion) and [mode name](https://learn.microsoft.com/ja-jp/azure/azure-resource-manager/templates/deployment-modes#complete-mode) are `完全モード`, so this is a fix for consistency.
